### PR TITLE
[FIXED JENKINS-14656] Pass UpstreamCause as well as MyUserIdCause in a single CauseAction

### DIFF
--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -490,7 +490,9 @@ public class BuildPipelineView extends View {
         LOGGER.fine("Triggering build for project: " + triggerProject.getFullDisplayName()); //$NON-NLS-1$
         final Cause.UpstreamCause upstreamCause = (null == upstreamBuild) ? null : new Cause.UpstreamCause((Run<?, ?>) upstreamBuild);
         final List<Action> buildActions = new ArrayList<Action>();
-        buildActions.add(new CauseAction(new MyUserIdCause()));
+        CauseAction causeAction = new CauseAction(new MyUserIdCause());
+        causeAction.getCauses().add(upstreamCause);
+        buildActions.add(causeAction);
         ParametersAction parametersAction =
                 buildParametersAction instanceof ParametersAction
                         ? (ParametersAction) buildParametersAction : new ParametersAction();
@@ -521,7 +523,7 @@ public class BuildPipelineView extends View {
 
         buildActions.add(parametersAction);
 
-        triggerProject.scheduleBuild(triggerProject.getQuietPeriod(), upstreamCause, buildActions.toArray(new Action[buildActions.size()]));
+        triggerProject.scheduleBuild(triggerProject.getQuietPeriod(), null, buildActions.toArray(new Action[buildActions.size()]));
         return triggerProject.getNextBuildNumber();
     }
 


### PR DESCRIPTION
[JENKINS-14656](https://issues.jenkins-ci.org/browse/JENKINS-14656): e.g. Copy Artifact’s plugin’s `TriggeredBuildSelector` calls `Run.getCauses` which only looks for a single `CauseAction`. Need to put all the `Cause`s into this one.
