### PR TITLE
ignoring IntelliJ files in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 target
 work
 /target
+
+# IntelliJ
+.idea/
+*.iml
+*.ipr
+*.iws


### PR DESCRIPTION
Ignoring the IntelliJ files brings `.gitignore` a little closer to parity with `.hgignore`
