### PR TITLE
[FIXED JENKINS-19896] removing unprocessed -moz prefixed css

### DIFF
--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -37,7 +37,6 @@
     background: #000000;
     position: absolute;
     top: 0;
-    -moz-opacity:0.6;
     -khtml-opacity: 0.6;
     opacity: 0.6;
     filter:alpha(opacity=75);
@@ -82,7 +81,6 @@
 	-o-text-overflow: ellipsis;
 	-icab-text-overflow: ellipsis;
 	-khtml-text-overflow: ellipsis;
-	-moz-text-overflow: ellipsis;
 	-webkit-text-overflow: ellipsis;
 	text-overflow: ellipsis;
 	overflow: hidden;
@@ -94,15 +92,12 @@
 .rounded {
     height: 70px;
 	width: 141px !important;
-    -moz-opacity: 0.9;
     -webkit-opacity: 0.9;
     opacity: 0.9;
 
-    -moz-border-radius: 4px;
     -webkit-border-radius: 4px;
     border-radius: 4px;
 
-    -moz-box-shadow: 4px 4px 4px #555;
     -webkit-box-shadow: 4px 4px 4px #555;
     box-shadow: 4px 4px 4px #555;
 
@@ -118,11 +113,9 @@
     color: #333;
     padding: 3px;
 
-    -moz-border-radius-topright: 4px;
     -webkit-border-top-right-radius: 4px;
     border-top-right-radius: 4px;
 
-    -moz-border-radius-topleft: 4px;
     -webkit-border-top-left-radius: 4px;
     border-top-left-radius: 4px;
 }
@@ -227,25 +220,21 @@ tbody.pipelineGroup {
 }
 
 tbody > tr:first-child > td:first-child {
-    -moz-border-radius-topleft: 4px;
     -webkit-border-top-left-radius: 4px;
     border-top-left-radius: 4px;
 }
 
 tbody >  tr:first-child > td:last-child {
-    -moz-border-radius-topright: 4px;
     -webkit-border-top-right-radius: 4px;
     border-top-right-radius: 4px;
 }
 
 tbody >  tr:last-child > td:first-child {
-    -moz-border-radius-bottomleft: 4px;
     -webkit-border-bottom-left-radius: 4px;
     border-bottom-left-radius: 4px;
 }
 
 tbody >  tr:last-child > td:last-child {
-    -moz-border-radius-bottomright: 4px;
     -webkit-border-bottom-right-radius: 4px;
     border-bottom-right-radius: 4px;
 }
@@ -347,7 +336,7 @@ tr.spacerRow td {
 }
 
 #projectHeader {
-    -moz-border-radius: 10px;
+    border-radius: 10px;
     -webkit-border-radius: 10px;
     border-width: 10px;
     font-size: 12px;


### PR DESCRIPTION
These currently show up as errors in the Firefox console. While they're not hurting anything, I'd like to help a little bit by getting rid of the unused `-moz` prefix declarations. Specifically: `-moz-box-shadow`, `-moz-border-radius`, `-moz-opacity`, and `-moz-text-overflow`.

unprefixed `box-shadow` has been supported since firefox 4.
see: https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow

unprefixed `border-radius` has been supported since firefox 4.
see: https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius

unprefixed `text-overflow` has been supported since firefox 7.
see: https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow

unprefixed `opacity` has been supported since firefox 1.
see: https://developer.mozilla.org/en-US/docs/Web/CSS/opacity
