### PR TITLE
[FIXED JENKINS-16098] restrict getItems() return value to related projects

### DIFF
--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -778,9 +778,8 @@ public class BuildPipelineView extends View {
                 for (int col = 0; col < grid.getColumns(); col++) {
                     final ProjectForm form = grid.get(row, col);
                     if (form != null) {
-                        TopLevelItem item;
                         try {
-                            item = Jenkins.getInstance().getItem(form.getName());
+                            final TopLevelItem item = Jenkins.getInstance().getItem(form.getName());
                             if (item != null) {
                                 items.add(item);
                             }


### PR DESCRIPTION
A fix for https://issues.jenkins-ci.org/browse/JENKINS-16098
Build pipeline view under nested view shows wrong status since BuildPipelineView.getItems() returns all projects.
I've fixed it by restricting return values to related projects.
