### PR TITLE
Drop core dependency to 1.509 (LTS line).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.521</version>
+		<version>1.509</version>
 	</parent>
 	<artifactId>build-pipeline-plugin</artifactId>
 	<version>1.4.3-SNAPSHOT</version>


### PR DESCRIPTION
Current code requires at least 1.489 (for 15ba345b), but 1.521 seems unjustified.
