### PR TITLE
Upgraded jenkins instance to 1.509.3.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.509</version>
+		<version>1.509.3</version>
 	</parent>
 	<artifactId>build-pipeline-plugin</artifactId>
 	<version>1.4.3-SNAPSHOT</version>

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/PipelineBuild.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/PipelineBuild.java
@@ -207,7 +207,7 @@ public class PipelineBuild {
      * @return URL of the currentBuild
      */
     public String getBuildResultURL() {
-        return currentBuild != null ? currentBuild.getUrl() : ""; //$NON-NLS-1$
+        return currentBuild != null ? currentBuild.getAbsoluteUrl() : ""; //$NON-NLS-1$
     }
 
     /**


### PR DESCRIPTION
Fixed issue where url was not being displayed properly if build pipeline view is inside a folder.
