### PR TITLE
Adjust the UI to fix a stretching-out issue.

### DIFF
--- a/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/bpp.jelly
+++ b/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/bpp.jelly
@@ -305,7 +305,16 @@
 								<j:forEach begin="${0}" end="${buildPipelineForm.getGridWidth() - 1}" indexVar="y">
 								<j:set var="project" type="au.com.centrumsystems.hudson.plugin.buildpipeline.ProjectForm" value="${projectGrid.get(x,y)}"/>
 									<j:if test="${project != null}">
-										<td id="project-${project.getId()}"></td>
+										<!-- Checking if the cell to be added corresponds to the one containing build parameters. -->
+										<j:choose>
+											<j:when test="${(y == 0 &amp;&amp; x == 0)}">
+												<!-- Expanding the cell to multiple rows in order to fix an issue which stretches the UI. -->
+												<td id="project-${project.getId()}" rowspan="${buildPipelineForm.getGridHeight()}"></td>
+											</j:when>
+											<j:otherwise>
+												<td id="project-${project.getId()}"></td>
+											</j:otherwise>
+										</j:choose>
 										<script>
                                             //save project proxies for future reference (being able to refresh project cards)
                                             buildPipeline.projectProxies[${project.getId()}] = <st:bind value="${project}" />;
@@ -324,7 +333,10 @@
 										</j:if>
 									</j:if>
 									<j:if test="${project == null}">
-										<td></td>
+										<!-- Skipping the "filler" td for the first colulmn. -->
+										<j:if test="${y != 0}">
+											<td></td>
+										</j:if>
 										<j:if test="${y + 1 != buildPipelineForm.getGridWidth()}">
 											<j:set var="nextIndex" value="${y + 1}"/>
 												<td class="next">
@@ -346,7 +358,8 @@
 					<tbody class="pipelineGroup">
 						<j:forEach begin="${0}" end="${buildGrid.rows - 1}" indexVar="x">
 							<tr class='build-pipeline'>
-								<td class="revision-cell"><j:if test="${x == 0}">
+									<!-- Only adding the revision-cell once. -->
+									<j:if test="${x == 0}"><td class="revision-cell" rowspan="${buildGrid.rows}">
 										<table class="revision rounded build-card">
 											<tbody>
 												<tr class="header">
@@ -402,7 +415,7 @@
 												</tr>
 											</tbody>
 										</table>
-									</j:if></td>
+									</td></j:if>
 								<td class="next"></td>
 								<j:forEach begin="${0}" end="${buildPipelineForm.getGridWidth() - 1}" indexVar="y">
 									<j:set var="build" type="au.com.centrumsystems.hudson.plugin.buildpipeline.BuildForm" value="${buildGrid.get(x,y)}" />

--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -211,7 +211,7 @@
 
 td.next {
     width: 40px;
-    vertical-align: middle;
+    vertical-align: top;
 }
 
 tbody.pipelineGroup {


### PR DESCRIPTION
Modify the bpp.jelly file which generates the build pipeline view,
in order to fix an issue which causes the build pipeline view to be
stretched out. When the build parameters field was larger than usual,
the cell would expand and stretch the table containing the build
pipeline. Modify main.css to ensure that the arrow images always
point to the next downstream job.
