### PR TITLE
Fix validation of downstream projects for Maven projects.

### DIFF
--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/trigger/BuildPipelineTrigger.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/trigger/BuildPipelineTrigger.java
@@ -58,7 +58,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
 import au.com.centrumsystems.hudson.plugin.buildpipeline.Strings;
-import hudson.model.ItemGroup;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.AncestorInPath;
 
@@ -293,10 +292,10 @@ public class BuildPipelineTrigger extends Notifier implements DependecyDeclarer 
          * Validates that the downstream project names entered are valid projects.
          *
          * @param value   - The entered project names
-         * @param context - the context
+         * @param project - the containing project
          * @return hudson.util.FormValidation
          */
-        public FormValidation doCheckDownstreamProjectNames(@AncestorInPath ItemGroup context,
+        public FormValidation doCheckDownstreamProjectNames(@AncestorInPath AbstractProject project,
                                                             @QueryParameter("downstreamProjectNames") final String value) {
             final StringTokenizer tokens = new StringTokenizer(Util.fixNull(value), ","); //$NON-NLS-1$
             boolean some = false;
@@ -306,10 +305,10 @@ public class BuildPipelineTrigger extends Notifier implements DependecyDeclarer 
                     continue;
                 }
                 some = true;
-                final Item item = Jenkins.getInstance().getItem(projectName, context, Item.class);
+                final Item item = Jenkins.getInstance().getItem(projectName, project, Item.class);
                 if (item == null) {
                     return FormValidation.error(Messages.BuildTrigger_NoSuchProject(projectName,
-                            AbstractProject.findNearest(projectName, context).getRelativeNameFrom(context)));
+                            AbstractProject.findNearest(projectName, project.getParent()).getRelativeNameFrom(project)));
                 }
                 if (!(item instanceof AbstractProject)) {
                     return FormValidation.error(Messages.BuildTrigger_NotBuildable(projectName));

--- a/src/test/java/au/com/centrumsystems/hudson/plugin/buildpipeline/trigger/BuildPipelineTriggerTest.java
+++ b/src/test/java/au/com/centrumsystems/hudson/plugin/buildpipeline/trigger/BuildPipelineTriggerTest.java
@@ -27,6 +27,8 @@ package au.com.centrumsystems.hudson.plugin.buildpipeline.trigger;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
+
+import hudson.model.AbstractProject;
 import hudson.model.Descriptor;
 import hudson.model.FreeStyleProject;
 import hudson.model.Hudson;
@@ -159,15 +161,17 @@ public class BuildPipelineTriggerTest extends HudsonTestCase {
 
     @Test
     public void testDoCheckDownstreamProjectNames() throws IOException, InterruptedException {
+        final AbstractProject upstreamProject = createFreeStyleProject("Upstream");
+
         final String proj1 = "Proj1";
         final String proj2 = "Proj2";
         createFreeStyleProject(proj1);
 
         final BuildPipelineTrigger.DescriptorImpl di = new BuildPipelineTrigger.DescriptorImpl();
 
-        assertEquals(FormValidation.ok(), di.doCheckDownstreamProjectNames(jenkins, proj1));
+        assertEquals(FormValidation.ok(), di.doCheckDownstreamProjectNames(upstreamProject, proj1));
         assertThat(FormValidation.error("No such project '" + proj2 + "'. Did you mean '" + proj1 + "'?").toString(), is(di
-                .doCheckDownstreamProjectNames(jenkins, proj2).toString()));
+                .doCheckDownstreamProjectNames(upstreamProject, proj2).toString()));
     }
 
     @Test


### PR DESCRIPTION
Hi,

There was a problem validating the upstream project name when you added a manual trigger to a Maven project. This was caused by the fact that a maven project is both an AbstractProject and an ItemGroup. So doCheckDownstreamProjectNames would be called with the maven project as argument instead of the containing folder. These changes should fix that.

The accompanying issue is JENKINS-22196.

Wilco
