### PR TITLE
Enable manual start for job with auto trigger

### DIFF
--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/PipelineBuild.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/PipelineBuild.java
@@ -442,7 +442,7 @@ public class PipelineBuild {
      * @return is ready to be manually built.
      */
     public boolean isReadyToBeManuallyBuilt() {
-     return isManualTrigger() && this.currentBuild == null && (upstreamBuildSucceeded() || upstreamBuildUnstable()) && hasBuildPermission();
+      return  this.currentBuild == null && (upstreamBuildSucceeded() || upstreamBuildUnstable()) && hasBuildPermission();
     }
 
     public boolean isRerunnable() {


### PR DESCRIPTION
In a pipeline, when we a job is launched with an automatic trigger and that it is successful, we sometimes want to restart it.
When the job has a manual trigger, we first delete that successful build in order to see the new one executed in the same pipeline view (Need an UpstreamCause). It works well.
But if the job has an automatic trigger, it is not possible to restart it.

I added the possibility to manually launch an automatic trigger job.
