### PR TITLE
Mask instead of remove sensitive parameters.

### DIFF
--- a/src/main/java/au/com/centrumsystems/hudson/plugin/util/BuildUtil.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/util/BuildUtil.java
@@ -172,7 +172,8 @@ public final class BuildUtil {
                 for (String paramName : sensitiveBuildVariables) {
                     if (retval.containsKey(paramName)) {
                         // We have the choice to hide the parameter or to replace it with special characters
-                        retval.remove(paramName);
+                        retval.put(paramName, "********");
+                        //retval.remove(paramName);
                     }
                 }
             }


### PR DESCRIPTION
Original fix removes the sensitive parameter and it can confuse the user, giving an idea that the parameter isn't correctly configured.
