### PR TITLE
better support for jobs within folders

### DIFF
--- a/src/main/groovy/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildJSONBuilder.groovy
+++ b/src/main/groovy/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildJSONBuilder.groovy
@@ -40,14 +40,14 @@ class BuildJSONBuilder {
 			}
 			project {
 				disabled(pipelineBuild.projectDisabled)
-				name(pipelineBuild.project.name)
+				name(pipelineBuild.project.getRelativeNameFrom(pipelineBuild.project.parent))
 				url(pipelineBuild.projectURL)
 				health(pipelineBuild.projectHealth)
 				id(projectId)
 				parameters(params)
 			}
 			upstream {
-				projectName(pipelineBuild.upstreamPipelineBuild?.project?.name)
+				projectName(pipelineBuild.upstreamPipelineBuild?.project?.getRelativeNameFrom(pipelineBuild.project.parent))
 				buildNumber(pipelineBuild.upstreamBuild?.number)
 			}
 		}

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -29,24 +29,9 @@ import com.google.common.collect.Iterables;
 
 import com.google.common.collect.Sets;
 import hudson.Extension;
-import hudson.model.Action;
-import hudson.model.Descriptor;
-import hudson.model.Item;
-import hudson.model.ParameterValue;
-import hudson.model.TaskListener;
-import hudson.model.TopLevelItem;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.Cause;
+import hudson.model.*;
 import hudson.model.Cause.UserIdCause;
-import hudson.model.CauseAction;
 import hudson.model.Descriptor.FormException;
-import hudson.model.Hudson;
-import hudson.model.ParametersAction;
-import hudson.model.Run;
-import hudson.model.User;
-import hudson.model.View;
-import hudson.model.ViewDescriptor;
 import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
 import hudson.plugins.parameterizedtrigger.BuildTrigger;
 import hudson.plugins.parameterizedtrigger.BuildTriggerConfig;
@@ -434,8 +419,9 @@ public class BuildPipelineView extends View {
      */
     @JavaScriptMethod
     public int triggerManualBuild(final Integer upstreamBuildNumber, final String triggerProjectName, final String upstreamProjectName) {
-        final AbstractProject<?, ?> triggerProject = (AbstractProject<?, ?>) super.getJob(triggerProjectName);
-        final AbstractProject<?, ?> upstreamProject = (AbstractProject<?, ?>) super.getJob(upstreamProjectName);
+        ItemGroup context = getOwnerItemGroup();
+        final AbstractProject<?, ?> triggerProject = (AbstractProject<?, ?>) Jenkins.getInstance().getItem(triggerProjectName, context);
+        final AbstractProject<?, ?> upstreamProject = (AbstractProject<?, ?>) Jenkins.getInstance().getItem(upstreamProjectName, context);
 
         final AbstractBuild<?, ?> upstreamBuild = retrieveBuild(upstreamBuildNumber, upstreamProject);
 


### PR DESCRIPTION
When pipeline includes jobs within folders, use relative path from view ItemGroup as job names, and resolve to jobs accordingly
