### PR TITLE
Add explicit disambiguation for Item/ItemGroup

### DIFF
--- a/src/main/groovy/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildJSONBuilder.groovy
+++ b/src/main/groovy/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildJSONBuilder.groovy
@@ -41,14 +41,28 @@ class BuildJSONBuilder {
 			}
 			project {
 				disabled(pipelineBuild.projectDisabled)
-				name(pipelineBuild.project.getRelativeNameFrom(context))
+				try {
+				  // Attempt to use this API, which is introduced in 1.515,
+				  // but allows this to work despite the Item/ItemGroup
+				  // overload ambiguity, when a 'context' is also an Item.
+				  name(pipelineBuild.project.getRelativeNameFromGroup(context))
+				} catch (e) {
+				  name(pipelineBuild.project.getRelativeNameFrom(context))
+				}
 				url(pipelineBuild.projectURL)
 				health(pipelineBuild.projectHealth)
 				id(projectId)
 				parameters(params)
 			}
 			upstream {
-				projectName(pipelineBuild.upstreamPipelineBuild?.project?.getRelativeNameFrom(context))
+				try {
+				  // Attempt to use this API, which is introduced in 1.515,
+				  // but allows this to work despite the Item/ItemGroup
+				  // overload ambiguity, when a 'context' is also an Item.
+				  projectName(pipelineBuild.upstreamPipelineBuild?.project?.getRelativeNameFromGroup(context))
+				} catch (e) {
+				  projectName(pipelineBuild.upstreamPipelineBuild?.project?.getRelativeNameFrom(context))
+				}
 				buildNumber(pipelineBuild.upstreamBuild?.number)
 			}
 		}


### PR DESCRIPTION
Add explicit disambiguation for Item/ItemGroup by attempting to access the getRelativeNameFromGroup API that is made available starting in 1.515.  If this method is not available, we fall back on what is there today, which cannot properly disambiguate between the Item overload and the ItemGroup overload when "context" is both (as is the case with some unreleased plugins).

I have tested this both with Jenkins core at 1.509.3 and at head (1.569).
