### PR TITLE
Trim comma separated list of trigger projects

### DIFF
--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -589,7 +589,7 @@ public class BuildPipelineView extends View {
         final BuildPipelineTrigger manualTrigger = upstreamProjectPublishersList.get(BuildPipelineTrigger.class);
         if (manualTrigger != null) {
             final Set<String> downstreamProjectsNames =
-                    Sets.newHashSet(Splitter.on(",").split(manualTrigger.getDownstreamProjectNames()));
+                    Sets.newHashSet(Splitter.on(",").trimResults().split(manualTrigger.getDownstreamProjectNames()));
             if (downstreamProjectsNames.contains(project.getName())) {
                 configs = manualTrigger.getConfigs();
             }
@@ -598,7 +598,7 @@ public class BuildPipelineView extends View {
         final BuildTrigger autoTrigger = upstreamProjectPublishersList.get(BuildTrigger.class);
         if (autoTrigger != null) {
             for (BuildTriggerConfig config : autoTrigger.getConfigs()) {
-                final Set<String> downstreamProjectsNames = Sets.newHashSet(Splitter.on(",").split(config.getProjects()));
+                final Set<String> downstreamProjectsNames = Sets.newHashSet(Splitter.on(",").trimResults().split(config.getProjects()));
                 if (downstreamProjectsNames.contains(project.getName())) {
                     configs = config.getConfigs();
                 }


### PR DESCRIPTION
This will fix the problem I described here:
http://goo.gl/lYcNPa

where it is not possible to manually trigger projects that are listed with spaces around the commas.
