### PR TITLE
Fix relative links on build pipeline

### DIFF
--- a/src/main/webapp/js/build-pipeline.js
+++ b/src/main/webapp/js/build-pipeline.js
@@ -102,7 +102,7 @@ BuildPipeline.prototype = {
 			type: 'iframe',
 			title: title,
 			titlePosition: 'outside',
-			href: href,
+			href: '/' + href,
 			transitionIn : 'elastic',
 			transitionOut : 'elastic',
 			width: '90%',


### PR DESCRIPTION
We have links broken in the pipeline view due to the links being relative instead of absolute (a '/' is missing)

This fixes the issue, and we may not be the only ones with that issue
