### PR TITLE
Improve speed of pipeline that has a lot of items.

### DIFF
--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -913,7 +913,7 @@ public class BuildPipelineView extends View {
         boolean display = true;
         //tester la liste vide seulement en lecture
         if (READ.name.equals(p.name)) {
-          Collection<TopLevelItem> items = this.getItems();
+          final Collection<TopLevelItem> items = this.getItems();
           if (items == null || items.isEmpty()) {
                 display = false;
             }


### PR DESCRIPTION
Remove duplicate `getItems()` call which can be expensive if a lot of items are in the pipeline.
