### PR TITLE
[FIXED Jenkins-23749] NPE when view contains no builds.

### DIFF
--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -241,7 +241,7 @@ public class BuildPipelineView extends View {
         super(name, Hudson.getInstance());
         this.buildViewTitle = buildViewTitle;
         this.gridBuilder = gridBuilder;
-        this.noOfDisplayedBuilds = (noOfDisplayedBuilds == null) ? "1" : noOfDisplayedBuilds;
+        this.noOfDisplayedBuilds = noOfDisplayedBuilds;
         this.triggerOnlyLatestJob = triggerOnlyLatestJob;
         this.cssUrl = cssUrl;
     }


### PR DESCRIPTION
If there are no builds in the pipeline (or you delete a folder with a pipeline in it), it will throw a NPE.
