### PR TITLE
M2Releases triggered from Pipeline View

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,19 +95,45 @@
 			<!-- only necessary if Hamcrest matchers are used -->
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-core</artifactId>
-			<version>1.2</version>
+			<version>1.3</version>
 			<scope>test</scope>
 		</dependency>
+		<!-- Need to update this version due to conflicts on maven* versions -->
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>dashboard-view</artifactId>
-			<version>2.2</version>
+			<version>2.9.4</version>
 			<optional>true</optional>
 		</dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>parameterized-trigger</artifactId>
             <version>2.17</version>
+        </dependency>
+        <!-- Additional dependencies to enable detection of maven builds, resp. maven release builds
+             The test-scoped dependencies are needed due to mismatches with the versions. -->
+        <dependency>
+        	<groupId>org.jenkins-ci.plugins.m2release</groupId>
+        	<artifactId>m2release</artifactId>
+        	<version>0.14.0</version>
+        </dependency>
+        <dependency>
+        	<groupId>org.apache.maven</groupId>
+        	<artifactId>maven-artifact</artifactId>
+        	<version>3.0.3</version>
+        	<scope>test</scope>
+        </dependency>
+        <dependency>
+        	<groupId>org.apache.maven</groupId>
+        	<artifactId>maven-model</artifactId>
+        	<version>3.0.3</version>
+        	<scope>test</scope>
+        </dependency>
+        <dependency>
+        	<groupId>org.apache.maven</groupId>
+        	<artifactId>maven-settings</artifactId>
+        	<version>3.0.3</version>
+        	<scope>test</scope>
         </dependency>
 
         <dependency>

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -72,6 +72,7 @@ import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
 
+import org.jvnet.hudson.plugins.m2release.M2ReleaseAction;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -931,5 +932,28 @@ public class BuildPipelineView extends View {
         }
 
         return display;
-    } 
+    }
+
+    /**
+     * Check for M2ReleaseAction, if present, then provide an icon on top
+     * 
+     * @return boolean - whether the first job is a m2release job
+     */
+    public boolean isM2Release() {
+        if (Jenkins.getInstance().getPlugin("m2release") == null) {
+            return false;
+        }
+        final String firstJobName = ((DownstreamProjectGridBuilder) gridBuilder).getFirstJob();
+        final AbstractProject<?, ?> project = Jenkins.getInstance().getItem(firstJobName, this.getOwnerItemGroup(),
+                AbstractProject.class);
+        if (project != null) {
+            // If a M2ReleaseAction is found
+            final List<M2ReleaseAction> actions = project.getActions(M2ReleaseAction.class);
+            if (actions != null && !actions.isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 }

--- a/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/bpp.jelly
+++ b/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/bpp.jelly
@@ -240,6 +240,14 @@
 			</j:if>
             <div>Run</div>
           </div>
+          <j:if test="${from.m2Release}">
+          <div class="icon-container">
+		    <div onclick="buildPipeline.fillDialog('${rootURL}/job/${from.gridBuilder.firstJob}/m2release', 'Starts the pipeline with a maven release build')" class="pointer">
+                <img src="${rootURL}/images/24x24/installer.gif" alt="M2Release in a Pipeline" class="icon-with-caption"/>
+            </div>
+            <div>Release</div>
+          </div>
+          </j:if>          
         </j:if>
 
 				<div class="icon-container">

--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -61,7 +61,7 @@
     height: 48px;
     margin-left: auto;
     margin-right: auto;
-    width: 340px;
+    width: 392px;
 }
 
 .icon-container {

--- a/src/main/webapp/js/build-pipeline.js
+++ b/src/main/webapp/js/build-pipeline.js
@@ -102,7 +102,7 @@ BuildPipeline.prototype = {
 			type: 'iframe',
 			title: title,
 			titlePosition: 'outside',
-			href: '/' + href,
+			href: href,
 			transitionIn : 'elastic',
 			transitionOut : 'elastic',
 			width: '90%',


### PR DESCRIPTION
By adding the dependency to the maven-release-plugin, it is possible now to run "perform maven release" from the pipeline view directly. This is done by adding a new icon on top, aside the "run" icon).
In addition I did take back the change of the href: '/' + href in the javascript file, it broke all light-boxes from the build-pipeline.
