### PR TITLE
Fix broken dialog when rootURL is blank

### DIFF
--- a/src/main/webapp/js/build-pipeline.js
+++ b/src/main/webapp/js/build-pipeline.js
@@ -102,7 +102,7 @@ BuildPipeline.prototype = {
 			type: 'iframe',
 			title: title,
 			titlePosition: 'outside',
-			href: '/' + href,
+			href: href.startsWith('/') ? href : '/' + href,
 			transitionIn : 'elastic',
 			transitionOut : 'elastic',
 			width: '90%',


### PR DESCRIPTION
`buildPipeline.fillDialog` adds `/` to the start of the URL given to it. Callers of `fillDialog` start URLs with `"${rootURL}/example"`. Together, this means that it tries to open `"//example"` when `rootURL` is blank. The result is a broken popup.
