### PR TITLE
make fillDialog work with URLs that start with /

### DIFF
--- a/src/main/webapp/js/build-pipeline.js
+++ b/src/main/webapp/js/build-pipeline.js
@@ -98,16 +98,22 @@ BuildPipeline.prototype = {
 		jQuery("#icons-" + id).empty();
 	},
 	fillDialog : function(href, title) {
-		jQuery.fancybox({
-			type: 'iframe',
-			title: title,
-			titlePosition: 'outside',
-			href: '/' + href,
-			transitionIn : 'elastic',
-			transitionOut : 'elastic',
-			width: '90%',
-			height: '80%'
-		});
+        // ensure an absolute path, without risking a double-slash, which
+        // causes browsers to interpret the first path component as a
+        // domain name.
+        if(href.charAt(0) != '/') {
+            href = '/' + href;
+        }
+        jQuery.fancybox({
+            type: 'iframe',
+            title: title,
+            titlePosition: 'outside',
+            href: href,
+            transitionIn : 'elastic',
+            transitionOut : 'elastic',
+            width: '90%',
+            height: '80%'
+        });
 	},
 	closeDialog : function() {
 		jQuery.fancybox.close();


### PR DESCRIPTION
fillDialog was up until now prepending the URL with a slash regardless
of the actual URL argument. If it got called with a URL starting with /,
the resulting URL would start with double slashes and have its first
directory interpreted as a domain by the browser, causing a "server not
found" error on the interface.
