### PR TITLE
[FIXED JENKINS-22665] Fixes for JENKINS-22665 and JENKINS-19755

### DIFF
--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -33,7 +33,6 @@ import hudson.model.Action;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.ParameterValue;
-import hudson.model.TaskListener;
 import hudson.model.TopLevelItem;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
@@ -45,7 +44,6 @@ import hudson.model.Descriptor.FormException;
 import hudson.model.Hudson;
 import hudson.model.ParametersAction;
 import hudson.model.Run;
-import hudson.model.User;
 import hudson.model.View;
 import hudson.model.ViewDescriptor;
 import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
@@ -151,71 +149,12 @@ public class BuildPipelineView extends View {
     private static final Logger LOGGER = Logger.getLogger(BuildPipelineView.class.getName());
 
     /**
-     * An instance of {@link Cause.UserIdCause} related to the current user. Must be transient, or xstream will include it in the
-     * serialization
+     * An instance of {@link Cause.UserIdCause} related to the current user.
+     * Just kept for backwards comparability.
+     * @deprecated Use Cause.UserIdCause instead
      */
-    private class MyUserIdCause extends Cause.UserIdCause {
-        /**
-         * user
-         */
-        private User user;
-
-        /**
-         *
-         */
-        public MyUserIdCause() {
-            try {
-                // this block can generate a CyclicGraphDetector.CycleDetectedException
-                // in cases that I haven't quite figured out yet
-                // also an org.acegisecurity.AccessDeniedException when the user
-                // is not logged in
-                user = Hudson.getInstance().getMe();
-            } catch (final Exception e) {
-                // do nothing
-                LOGGER.fine(e.getMessage());
-            }
-        }
-
-        @Override
-        public String getUserId() {
-            return (null == user) ? null : user.getId();
-        }
-
-        @Override
-        public String getUserName() {
-            return (null == user) ? null : user.getDisplayName();
-        }
-
-        @Override
-        public String toString() {
-            return getUserName();
-        }
-
-        @Override
-        public int hashCode() {
-            if (getUserId() == null) {
-                return super.hashCode();
-            } else {
-                return getUserId().hashCode();
-            }
-        }
-
-        @Override
-        public boolean equals(final Object o) {
-            if (null == o) {
-                return false;
-            }
-            if (!(o instanceof Cause.UserIdCause)) {
-                return false;
-            }
-
-            return hashCode() == o.hashCode();
-        }
-
-        @Override
-        public void print(final TaskListener listener) {
-            // do nothing
-        }
+    @Deprecated
+    private static class MyUserIdCause extends Cause.UserIdCause {
     }
 
     /**
@@ -505,7 +444,7 @@ public class BuildPipelineView extends View {
             final Action buildParametersAction) {
         LOGGER.fine("Triggering build for project: " + triggerProject.getFullDisplayName()); //$NON-NLS-1$
         final List<Action> buildActions = new ArrayList<Action>();
-        final CauseAction causeAction = new CauseAction(new MyUserIdCause());
+        final CauseAction causeAction = new CauseAction(new UserIdCause());
         if (upstreamBuild != null) {
             causeAction.getCauses().add(new Cause.UpstreamCause((Run<?, ?>) upstreamBuild));
         }

--- a/src/test/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineViewTest.java
+++ b/src/test/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineViewTest.java
@@ -25,6 +25,7 @@
 package au.com.centrumsystems.hudson.plugin.buildpipeline;
 
 import hudson.model.Action;
+import hudson.model.Cause;
 import hudson.model.FreeStyleBuild;
 import hudson.model.ItemGroup;
 import hudson.model.TopLevelItem;
@@ -41,11 +42,15 @@ import java.util.List;
 
 import jenkins.model.Jenkins;
 
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.Bug;
 
 import au.com.centrumsystems.hudson.plugin.buildpipeline.trigger.BuildPipelineTrigger;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
+
+import static org.junit.Assert.*;
 
 /**
  * Test Build Pipeline View
@@ -53,13 +58,11 @@ import au.com.centrumsystems.hudson.plugin.buildpipeline.trigger.BuildPipelineTr
  * @author Centrum Systems
  * 
  */
-public class BuildPipelineViewTest extends HudsonTestCase {
+public class BuildPipelineViewTest {
 
-    @Override
-    @Before
-    public void setUp() throws Exception {
-        super.setUp();
-    }
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
 
     @Test
     public void testGetSelectedProject() throws IOException {
@@ -67,7 +70,7 @@ public class BuildPipelineViewTest extends HudsonTestCase {
         final String bpViewTitle = "MyTestViewTitle";
         final String proj1 = "Proj1";
         final String noOfBuilds = "5";
-        createFreeStyleProject(proj1);
+        jenkins.createFreeStyleProject(proj1);
 
 		// Test a valid case
         DownstreamProjectGridBuilder gridBuilder = new DownstreamProjectGridBuilder(proj1);
@@ -91,7 +94,7 @@ public class BuildPipelineViewTest extends HudsonTestCase {
         final String bpViewTitle = "MyTestViewTitle";
         final String proj1 = "Proj1";
         final String noOfBuilds = "5";
-        final FreeStyleProject project1 = createFreeStyleProject(proj1);
+        final FreeStyleProject project1 = jenkins.createFreeStyleProject(proj1);
 
 		final BuildPipelineView testView = new BuildPipelineView(bpViewName, bpViewTitle,
                 new DownstreamProjectGridBuilder(proj1), noOfBuilds, false, null);
@@ -104,7 +107,7 @@ public class BuildPipelineViewTest extends HudsonTestCase {
         final String bpViewTitle = "MyTestViewTitle";
         final String proj1 = "Proj1";
         final String noOfBuilds = "5";
-        createFreeStyleProject(proj1);
+        jenkins.createFreeStyleProject(proj1);
 
 		// True
 		BuildPipelineView testView = new BuildPipelineView(bpViewName, bpViewTitle, new DownstreamProjectGridBuilder(proj1), noOfBuilds, true, null);
@@ -121,7 +124,7 @@ public class BuildPipelineViewTest extends HudsonTestCase {
         final String bpViewTitle = "MyTestViewTitle";
         final String proj1 = "Proj1";
         final String noOfBuilds = "5";
-        createFreeStyleProject(proj1);
+        jenkins.createFreeStyleProject(proj1);
 
 		// True
 		BuildPipelineView testView = new BuildPipelineView(bpViewName, bpViewTitle, new DownstreamProjectGridBuilder(proj1), noOfBuilds, true, true, false, false, false, 2, null, null);
@@ -138,7 +141,7 @@ public class BuildPipelineViewTest extends HudsonTestCase {
         final String bpViewTitle = "MyTestViewTitle";
         final String proj1 = "Proj1";
         final String noOfBuilds = "5";
-        createFreeStyleProject(proj1);
+        jenkins.createFreeStyleProject(proj1);
 
 		// True
 		BuildPipelineView testView = new BuildPipelineView(bpViewName, bpViewTitle, new DownstreamProjectGridBuilder(proj1), noOfBuilds, true, false, false, false, true, 2, null, null);
@@ -155,7 +158,7 @@ public class BuildPipelineViewTest extends HudsonTestCase {
         final String bpViewTitle = "MyTestViewTitle";
         final String proj1 = "Proj1";
         final String noOfBuilds = "5";
-        createFreeStyleProject(proj1);
+        jenkins.createFreeStyleProject(proj1);
 
 		// True
 		BuildPipelineView testView = new BuildPipelineView(bpViewName, bpViewTitle, new DownstreamProjectGridBuilder(proj1), noOfBuilds, true, false, true, false, false, 2, null, null);
@@ -172,7 +175,7 @@ public class BuildPipelineViewTest extends HudsonTestCase {
         final String bpViewTitle = "MyTestViewTitle";
         final String proj1 = "Proj1";
         final String noOfBuilds = "5";
-        createFreeStyleProject(proj1);
+        jenkins.createFreeStyleProject(proj1);
 
         BuildPipelineView testView = new BuildPipelineView(bpViewName, bpViewTitle, new DownstreamProjectGridBuilder(proj1), noOfBuilds, true, false, true, true, false, 2, null, null);
         assertTrue("Failed to set ShowPipelineParametersInHeaders flag", testView.isShowPipelineParametersInHeaders());
@@ -188,8 +191,8 @@ public class BuildPipelineViewTest extends HudsonTestCase {
 		final String proj1 = "Proj1";
 		final String proj2 = "Proj2";
 		final String noOfBuilds = "5";
-		final FreeStyleProject project1 = createFreeStyleProject(proj1);
-		final FreeStyleProject project2 = createFreeStyleProject(proj2);
+		final FreeStyleProject project1 = jenkins.createFreeStyleProject(proj1);
+		final FreeStyleProject project2 = jenkins.createFreeStyleProject(proj2);
 
         // Add project2 as a post build action: build other project
         project1.getPublishersList().add(new BuildPipelineTrigger(proj2, null));
@@ -212,8 +215,8 @@ public class BuildPipelineViewTest extends HudsonTestCase {
         final String proj1 = "Proj1";
         final String proj2 = "Proj2";
         final String noOfBuilds = "5";
-        final FreeStyleProject project1 = createFreeStyleProject(proj1);
-        final FreeStyleProject project2 = createFreeStyleProject(proj2);
+        final FreeStyleProject project1 = jenkins.createFreeStyleProject(proj1);
+        final FreeStyleProject project2 = jenkins.createFreeStyleProject(proj2);
 
         // Add project2 as a post build action: build other project
         project1.getPublishersList().add(new BuildPipelineTrigger(proj2, null));
@@ -238,9 +241,9 @@ public class BuildPipelineViewTest extends HudsonTestCase {
         final String proj3 = "Proj3";
         FreeStyleBuild build1;
         final String noOfBuilds = "5";
-        final FreeStyleProject project1 = createFreeStyleProject(proj1);
-        final FreeStyleProject project2 = createFreeStyleProject(proj2);
-        final FreeStyleProject project3 = createFreeStyleProject(proj3);
+        final FreeStyleProject project1 = jenkins.createFreeStyleProject(proj1);
+        final FreeStyleProject project2 = jenkins.createFreeStyleProject(proj2);
+        final FreeStyleProject project3 = jenkins.createFreeStyleProject(proj3);
 
         // Add project2 as a post build action: build other project
         project1.getPublishersList().add(new BuildPipelineTrigger(proj2, null));
@@ -251,8 +254,8 @@ public class BuildPipelineViewTest extends HudsonTestCase {
         Hudson.getInstance().rebuildDependencyGraph();
 
         // Build project1
-        build1 = buildAndAssertSuccess(project1);
-        waitUntilNoActivity();
+        build1 = jenkins.buildAndAssertSuccess(project1);
+        jenkins.waitUntilNoActivity();
 
 		// Test a valid case
 		final BuildPipelineView testView = BuildPipelineViewFactory.getBuildPipelineView(bpViewName, bpViewTitle, new DownstreamProjectGridBuilder(proj1), noOfBuilds, false);
@@ -262,13 +265,13 @@ public class BuildPipelineViewTest extends HudsonTestCase {
         final List<Action> buildActions = new ArrayList<Action>();
         project2.scheduleBuild(0, upstreamCause,
                 buildActions.toArray(new Action[buildActions.size()]));
-        waitUntilNoActivity();
+        jenkins.waitUntilNoActivity();
 
         upstreamCause = new hudson.model.Cause.UpstreamCause(
                 (Run<?, ?>) project2.getBuildByNumber(1));
         project3.scheduleBuild(0, upstreamCause,
                 buildActions.toArray(new Action[buildActions.size()]));
-        waitUntilNoActivity();
+        jenkins.waitUntilNoActivity();
 
         final BuildPipelineForm testForm = testView.getBuildPipelineForm();
 
@@ -289,7 +292,7 @@ public class BuildPipelineViewTest extends HudsonTestCase {
         final String proj2 = "Proj2";
         final String proj3 = "Proj3";
         final String noOfBuilds = "5";
-        final FreeStyleProject project1 = createFreeStyleProject(proj1);
+        final FreeStyleProject project1 = jenkins.createFreeStyleProject(proj1);
 
         // Add project2 as a post build action: build other project
         project1.getPublishersList().add(new BuildPipelineTrigger(proj2, null));
@@ -312,7 +315,7 @@ public class BuildPipelineViewTest extends HudsonTestCase {
         final String bpViewTitle = "MyTestViewTitle";
         final String proj1 = "Proj1";
         final String noOfBuilds = "5";
-        final FreeStyleProject project1 = createFreeStyleProject(proj1);
+        final FreeStyleProject project1 = jenkins.createFreeStyleProject(proj1);
 
 		final BuildPipelineView testView = new BuildPipelineView(bpViewName, bpViewTitle,
                 new DownstreamProjectGridBuilder(proj1), noOfBuilds, false, null);
@@ -321,7 +324,7 @@ public class BuildPipelineViewTest extends HudsonTestCase {
 		assertTrue(testView.getItems().contains(item1));
 
         final String proj2 = "Proj2";
-        final FreeStyleProject project2 = createFreeStyleProject(proj2);
+        final FreeStyleProject project2 = jenkins.createFreeStyleProject(proj2);
         TopLevelItem item2 = Jenkins.getInstance().getItem(proj2);
         assertNotNull(item2);
         assertFalse(testView.getItems().contains(item2));
@@ -339,6 +342,18 @@ public class BuildPipelineViewTest extends HudsonTestCase {
                 noOfBuilds, false, null);
 
         assertTrue(testView.hasPermission(Permission.READ));
+    }
+
+    @Test
+    @LocalData
+    @Bug(19755)
+    public void testMyUserIdCauseConversion() throws Exception {
+        FreeStyleProject projectB = (FreeStyleProject) jenkins.getInstance().getItem("B");
+        FreeStyleBuild buildB = projectB.getBuildByNumber(1);
+        assertNotNull(buildB);
+        Cause.UserIdCause cause = buildB.getCause(Cause.UserIdCause.class);
+        assertNotNull(cause);
+        assertEquals("bill", cause.getUserId());
     }
 
     /**

--- a/src/test/java/au/com/centrumsystems/hudson/plugin/buildpipeline/trigger/BuildPipelineTriggerTest.java
+++ b/src/test/java/au/com/centrumsystems/hudson/plugin/buildpipeline/trigger/BuildPipelineTriggerTest.java
@@ -28,8 +28,12 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
+import au.com.centrumsystems.hudson.plugin.buildpipeline.BuildPipelineView;
+import au.com.centrumsystems.hudson.plugin.buildpipeline.DownstreamProjectGridBuilder;
 import hudson.model.AbstractProject;
+import hudson.model.Cause;
 import hudson.model.Descriptor;
+import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Hudson;
 import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
@@ -40,9 +44,12 @@ import hudson.util.FormValidation;
 import java.io.IOException;
 import java.util.Collections;
 
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.Bug;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.*;
 
 /**
  * BuildPipelineTrigger test class
@@ -50,29 +57,21 @@ import org.jvnet.hudson.test.HudsonTestCase;
  * @author Centrum Systems
  *
  */
-public class BuildPipelineTriggerTest extends HudsonTestCase {
+public class BuildPipelineTriggerTest {
 
-    @Override
-    @Before
-    protected void setUp() throws Exception {
-        super.setUp();
-    }
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
 
     @Test(expected = IllegalArgumentException.class)
     public void testInvalidConstructor() {
-        try {
-            new BuildPipelineTrigger(null, null);
-            fail("An IllegalArgumentException should have been thrown.");
-        } catch (final IllegalArgumentException e) {
-
-        }
+        new BuildPipelineTrigger(null, null);
     }
 
     @Test
     public void testBuildPipelineTrigger() throws IOException {
         final String proj1 = "Proj1";
         final String proj2 = "Proj2";
-        final FreeStyleProject project1 = createFreeStyleProject(proj1);
+        final FreeStyleProject project1 = jenkins.createFreeStyleProject(proj1);
         // Add TEST_PROJECT2 as a post build action: build other project
         project1.getPublishersList().add(new BuildPipelineTrigger(proj2, null));
         // Important; we must do this step to ensure that the dependency graphs are updated
@@ -122,8 +121,8 @@ public class BuildPipelineTriggerTest extends HudsonTestCase {
         final String proj1 = "Proj1";
         final String proj2 = "Proj2";
         final String proj3 = "Proj3";
-        final FreeStyleProject project1 = createFreeStyleProject(proj1);
-        final FreeStyleProject project2 = createFreeStyleProject(proj2);
+        final FreeStyleProject project1 = jenkins.createFreeStyleProject(proj1);
+        final FreeStyleProject project2 = jenkins.createFreeStyleProject(proj2);
         project1.getPublishersList().add(new BuildPipelineTrigger(proj2 + "," + proj3, null));
         Hudson.getInstance().rebuildDependencyGraph();
 
@@ -143,8 +142,8 @@ public class BuildPipelineTriggerTest extends HudsonTestCase {
         final String proj1 = "Proj1";
         final String proj2 = "Proj2";
         final String proj3 = "Proj3";
-        final FreeStyleProject project1 = createFreeStyleProject(proj1);
-        final FreeStyleProject project2 = createFreeStyleProject(proj2);
+        final FreeStyleProject project1 = jenkins.createFreeStyleProject(proj1);
+        final FreeStyleProject project2 = jenkins.createFreeStyleProject(proj2);
         project1.getPublishersList().add(new BuildPipelineTrigger(proj2 + "," + proj3, null));
         Hudson.getInstance().rebuildDependencyGraph();
 
@@ -161,11 +160,11 @@ public class BuildPipelineTriggerTest extends HudsonTestCase {
 
     @Test
     public void testDoCheckDownstreamProjectNames() throws IOException, InterruptedException {
-        final AbstractProject upstreamProject = createFreeStyleProject("Upstream");
+        final AbstractProject upstreamProject = jenkins.createFreeStyleProject("Upstream");
 
         final String proj1 = "Proj1";
         final String proj2 = "Proj2";
-        createFreeStyleProject(proj1);
+        jenkins.createFreeStyleProject(proj1);
 
         final BuildPipelineTrigger.DescriptorImpl di = new BuildPipelineTrigger.DescriptorImpl();
 
@@ -178,7 +177,7 @@ public class BuildPipelineTriggerTest extends HudsonTestCase {
     public void testRemoveDownstreamTrigger() throws IOException, InterruptedException {
         final String proj1 = "Proj1";
         final String proj2 = "Proj2";
-        final FreeStyleProject project1 = createFreeStyleProject(proj1);
+        final FreeStyleProject project1 = jenkins.createFreeStyleProject(proj1);
         final BuildPipelineTrigger buildPipelineTrigger = new BuildPipelineTrigger(proj2, null);
         project1.getPublishersList().add(buildPipelineTrigger);
         Hudson.getInstance().rebuildDependencyGraph();
@@ -197,7 +196,7 @@ public class BuildPipelineTriggerTest extends HudsonTestCase {
     @Test
     public void testCyclicDownstreamTrigger() throws IOException, InterruptedException {
         final String proj1 = "Proj1";
-        final FreeStyleProject project1 = createFreeStyleProject(proj1);
+        final FreeStyleProject project1 = jenkins.createFreeStyleProject(proj1);
         final BuildPipelineTrigger cyclicPipelineTrigger = new BuildPipelineTrigger(proj1, null);
         project1.getPublishersList().add(cyclicPipelineTrigger);
         Hudson.getInstance().rebuildDependencyGraph();
@@ -217,5 +216,29 @@ public class BuildPipelineTriggerTest extends HudsonTestCase {
         final BuildPipelineTrigger.DescriptorImpl di = new BuildPipelineTrigger.DescriptorImpl();
 
         assertThat(di.getBuilderConfigDescriptors(), is(not(Collections.<Descriptor<AbstractBuildParameters>>emptyList())));
+    }
+
+    @Test
+    @Bug(22665)
+    public void testManualTriggerCause() throws Exception {
+        FreeStyleProject projectA = jenkins.createFreeStyleProject("A");
+        FreeStyleProject projectB = jenkins.createFreeStyleProject("B");
+        projectA.getPublishersList().add(new BuildPipelineTrigger("B", null));
+        jenkins.getInstance().rebuildDependencyGraph();
+
+        BuildPipelineView view = new BuildPipelineView("Pipeline", "Title", new DownstreamProjectGridBuilder("A"), "1", false, "");
+
+        jenkins.buildAndAssertSuccess(projectA);
+
+        view.triggerManualBuild(1, "B", "A");
+        jenkins.waitUntilNoActivity();
+
+        assertNotNull(projectB.getLastBuild());
+        FreeStyleBuild build = projectB.getLastBuild();
+        Cause.UserIdCause cause = build.getCause(Cause.UserIdCause.class);
+        assertNotNull(cause);
+        //Check that cause is of core class Cause.UserIdCause and not MyUserIdCause
+        assertEquals(Cause.UserIdCause.class.getName(), cause.getClass().getName());
+
     }
 }

--- a/src/test/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineViewTest/testMyUserIdCauseConversion/config.xml
+++ b/src/test/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineViewTest/testMyUserIdCauseConversion/config.xml
@@ -1,0 +1,60 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson>
+  <disabledAdministrativeMonitors/>
+  <version>1.0</version>
+  <numExecutors>2</numExecutors>
+  <mode>NORMAL</mode>
+  <useSecurity>true</useSecurity>
+  <authorizationStrategy class="hudson.security.AuthorizationStrategy$Unsecured"/>
+  <securityRealm class="hudson.security.HudsonPrivateSecurityRealm">
+    <disableSignup>false</disableSignup>
+    <enableCaptcha>false</enableCaptcha>
+  </securityRealm>
+  <disableRememberMe>false</disableRememberMe>
+  <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+  <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULLNAME}</workspaceDir>
+  <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+  <markupFormatter class="hudson.markup.EscapedMarkupFormatter"/>
+  <jdks/>
+  <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+  <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+  <clouds/>
+  <slaves/>
+  <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+  <views>
+    <hudson.model.AllView>
+      <owner class="hudson" reference="../../.."/>
+      <name>All</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+    </hudson.model.AllView>
+    <au.com.centrumsystems.hudson.plugin.buildpipeline.BuildPipelineView plugin="build-pipeline-plugin@1.4.6-SNAPSHOT">
+      <owner class="hudson" reference="../../.."/>
+      <name>Pipeline</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+      <gridBuilder class="au.com.centrumsystems.hudson.plugin.buildpipeline.DownstreamProjectGridBuilder">
+        <firstJob>A</firstJob>
+      </gridBuilder>
+      <noOfDisplayedBuilds>1</noOfDisplayedBuilds>
+      <buildViewTitle>Component</buildViewTitle>
+      <consoleOutputLinkStyle>Lightbox</consoleOutputLinkStyle>
+      <cssUrl></cssUrl>
+      <triggerOnlyLatestJob>false</triggerOnlyLatestJob>
+      <alwaysAllowManualTrigger>false</alwaysAllowManualTrigger>
+      <showPipelineParameters>false</showPipelineParameters>
+      <showPipelineParametersInHeaders>false</showPipelineParametersInHeaders>
+      <startsWithParameters>false</startsWithParameters>
+      <refreshFrequency>3</refreshFrequency>
+      <showPipelineDefinitionHeader>false</showPipelineDefinitionHeader>
+    </au.com.centrumsystems.hudson.plugin.buildpipeline.BuildPipelineView>
+  </views>
+  <primaryView>All</primaryView>
+  <slaveAgentPort>0</slaveAgentPort>
+  <label></label>
+  <nodeProperties/>
+  <globalNodeProperties/>
+</hudson>
+

--- a/src/test/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineViewTest/testMyUserIdCauseConversion/jobs/B/builds/2015-01-06_09-41-20/build.xml
+++ b/src/test/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineViewTest/testMyUserIdCauseConversion/jobs/B/builds/2015-01-06_09-41-20/build.xml
@@ -1,0 +1,131 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<build>
+  <actions>
+    <hudson.model.CauseAction>
+      <causes>
+        <au.com.centrumsystems.hudson.plugin.buildpipeline.BuildPipelineView_-MyUserIdCause plugin="build-pipeline-plugin@1.4.6-SNAPSHOT">
+          <userId>bill</userId>
+          <user>
+            <fullName>Bill</fullName>
+            <properties>
+              <hudson.model.PaneStatusProperties>
+                <collapsed/>
+              </hudson.model.PaneStatusProperties>
+              <jenkins.security.ApiTokenProperty>
+                <apiToken>zqhgv1MO6S/URSw9m3nluT585iGFYQf1o9n7t0gt/sX04Te1VucWSZnzOxxepbme</apiToken>
+              </jenkins.security.ApiTokenProperty>
+              <com.cloudbees.plugins.credentials.UserCredentialsProvider_-UserCredentialsProperty plugin="credentials@1.9.4">
+                <domainCredentialsMap class="hudson.util.CopyOnWriteMap$Hash"/>
+              </com.cloudbees.plugins.credentials.UserCredentialsProvider_-UserCredentialsProperty>
+              <hudson.model.MyViewsProperty>
+                <views>
+                  <hudson.model.AllView>
+                    <owner class="hudson.model.MyViewsProperty" reference="../../.."/>
+                    <name>All</name>
+                    <filterExecutors>false</filterExecutors>
+                    <filterQueue>false</filterQueue>
+                    <properties class="hudson.model.View$PropertyList"/>
+                  </hudson.model.AllView>
+                </views>
+              </hudson.model.MyViewsProperty>
+              <hudson.search.UserSearchProperty>
+                <insensitiveSearch>false</insensitiveSearch>
+              </hudson.search.UserSearchProperty>
+              <hudson.security.HudsonPrivateSecurityRealm_-Details>
+                <passwordHash>#jbcrypt:$2a$10$Kr4OK/gWKKkCWc3cUefmwuYX1baa.78FfzIyuN3FacaNKOuWxhlhm</passwordHash>
+              </hudson.security.HudsonPrivateSecurityRealm_-Details>
+              <hudson.tasks.Mailer_-UserProperty plugin="mailer@1.8">
+                <emailAddress>bill@bill.org</emailAddress>
+              </hudson.tasks.Mailer_-UserProperty>
+            </properties>
+          </user>
+          <outer-class>
+            <owner class="hudson.model.Hudson">
+              <disabledAdministrativeMonitors/>
+              <version>1.0</version>
+              <numExecutors>2</numExecutors>
+              <mode>NORMAL</mode>
+              <useSecurity>true</useSecurity>
+              <authorizationStrategy class="hudson.security.AuthorizationStrategy$Unsecured"/>
+              <securityRealm class="hudson.security.HudsonPrivateSecurityRealm">
+                <disableSignup>false</disableSignup>
+                <enableCaptcha>false</enableCaptcha>
+              </securityRealm>
+              <disableRememberMe>false</disableRememberMe>
+              <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+              <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULLNAME}</workspaceDir>
+              <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+              <markupFormatter class="hudson.markup.EscapedMarkupFormatter"/>
+              <jdks/>
+              <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+              <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+              <clouds/>
+              <slaves/>
+              <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+              <views>
+                <hudson.model.AllView>
+                  <owner class="hudson.model.Hudson" reference="../../.."/>
+                  <name>All</name>
+                  <filterExecutors>false</filterExecutors>
+                  <filterQueue>false</filterQueue>
+                  <properties class="hudson.model.View$PropertyList"/>
+                </hudson.model.AllView>
+                <au.com.centrumsystems.hudson.plugin.buildpipeline.BuildPipelineView reference="../../.."/>
+              </views>
+              <primaryView>All</primaryView>
+              <slaveAgentPort>0</slaveAgentPort>
+              <label></label>
+              <nodeProperties/>
+              <globalNodeProperties/>
+            </owner>
+            <name>Pipeline</name>
+            <filterExecutors>false</filterExecutors>
+            <filterQueue>false</filterQueue>
+            <properties class="hudson.model.View$PropertyList"/>
+            <gridBuilder class="au.com.centrumsystems.hudson.plugin.buildpipeline.DownstreamProjectGridBuilder">
+              <firstJob>A</firstJob>
+              <firstJobLink>job/A/</firstJobLink>
+            </gridBuilder>
+            <noOfDisplayedBuilds>1</noOfDisplayedBuilds>
+            <buildViewTitle>Component</buildViewTitle>
+            <consoleOutputLinkStyle>Lightbox</consoleOutputLinkStyle>
+            <cssUrl></cssUrl>
+            <triggerOnlyLatestJob>false</triggerOnlyLatestJob>
+            <alwaysAllowManualTrigger>false</alwaysAllowManualTrigger>
+            <showPipelineParameters>false</showPipelineParameters>
+            <showPipelineParametersInHeaders>false</showPipelineParametersInHeaders>
+            <startsWithParameters>false</startsWithParameters>
+            <refreshFrequency>3</refreshFrequency>
+            <showPipelineDefinitionHeader>false</showPipelineDefinitionHeader>
+          </outer-class>
+        </au.com.centrumsystems.hudson.plugin.buildpipeline.BuildPipelineView_-MyUserIdCause>
+        <hudson.model.Cause_-UpstreamCause>
+          <upstreamProject>A</upstreamProject>
+          <upstreamUrl>job/A/</upstreamUrl>
+          <upstreamBuild>1</upstreamBuild>
+          <upstreamCauses>
+            <hudson.model.Cause_-UserIdCause>
+              <userId>bill</userId>
+            </hudson.model.Cause_-UserIdCause>
+          </upstreamCauses>
+        </hudson.model.Cause_-UpstreamCause>
+      </causes>
+    </hudson.model.CauseAction>
+    <hudson.model.ParametersAction>
+      <parameters class="java.util.Arrays$ArrayList">
+        <a class="hudson.model.ParameterValue-array"/>
+      </parameters>
+    </hudson.model.ParametersAction>
+  </actions>
+  <number>1</number>
+  <startTime>1420533680028</startTime>
+  <result>SUCCESS</result>
+  <duration>33</duration>
+  <charset>UTF-8</charset>
+  <keepLog>false</keepLog>
+  <builtOn></builtOn>
+  <hudsonVersion>1.554.2</hudsonVersion>
+  <scm class="hudson.scm.NullChangeLogParser"/>
+  <culprits class="com.google.common.collect.EmptyImmutableSortedSet"/>
+</build>
+

--- a/src/test/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineViewTest/testMyUserIdCauseConversion/jobs/B/config.xml
+++ b/src/test/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineViewTest/testMyUserIdCauseConversion/jobs/B/config.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>
+


### PR DESCRIPTION
Remove the serialization of the User object within MyUserIdCause. Kept MyUserIdCause for backwards compatibility but is now just a simple subclass of the core class UserIdCause. 
This also fixes the JENKINS-19755 "Manual step "started by" username changes to anonymous after restart" since it now can load the correct user who triggered the build.
After upgrading it is possible to "Manage Old Data" to remove User object serialization of MyUserIdCause.