### PR TITLE
JENKINS-20499 

### DIFF
--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -545,11 +545,11 @@ public class BuildPipelineView extends View {
     private int triggerBuild(final AbstractProject<?, ?> triggerProject, final AbstractBuild<?, ?> upstreamBuild,
             final Action buildParametersAction) {
         LOGGER.fine("Triggering build for project: " + triggerProject.getFullDisplayName()); //$NON-NLS-1$
-        final Cause.UpstreamCause upstreamCause = (null == upstreamBuild) ? null : new Cause.UpstreamCause((Run<?, ?>) upstreamBuild);
         final List<Action> buildActions = new ArrayList<Action>();
         final CauseAction causeAction = new CauseAction(new MyUserIdCause());
-        // TODO hack obsolete as of 1.531 when CauseAction.<init>(Cause...) available:
-        causeAction.getCauses().add(upstreamCause);
+        if (upstreamBuild != null) {
+            causeAction.getCauses().add(new Cause.UpstreamCause((Run<?, ?>) upstreamBuild));
+        }
         buildActions.add(causeAction);
         ParametersAction parametersAction =
                 buildParametersAction instanceof ParametersAction

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/PipelineBuild.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/PipelineBuild.java
@@ -316,12 +316,10 @@ public class PipelineBuild {
             upstreamBuildName = "";
         }
         if (upstreamProjects.size() > 0) {
-            if (isManualTrigger()) {
-                for (AbstractProject upstreamProject : upstreamProjects) {
-                    if (upstreamProject.getName().equals(upstreamBuildName)) {
-                        previousProject = upstreamProject;
-                      break;
-                    }
+            for (AbstractProject upstreamProject : upstreamProjects) {
+                if (upstreamProject.getName().equals(upstreamBuildName)) {
+                    previousProject = upstreamProject;
+                  break;
                 }
             }
             if (previousProject == null) {

--- a/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/bpp.jelly
+++ b/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/bpp.jelly
@@ -124,9 +124,15 @@
 									{{/if}}
 								{{/if}}
 							{{else}}
-							<span class="pointer trigger" onclick="buildPipeline.showSpinner({{id}}); buildPipeline.triggerBuild({{id}}, '{{upstream.projectName}}', {{upstream.buildNumber}}, '{{project.name}}', [{{build.dependencyIds}}])">
-								<img title="retry" alt="retry" src="${rootURL}/images/16x16/redo.png" />
-							</span>
+								{{#if build.isManual}}
+									<span class="pointer trigger" onclick="buildPipeline.showSpinner({{id}}); buildPipeline.triggerBuild({{id}}, '{{upstream.projectName}}', {{upstream.buildNumber}}, '{{project.name}}', [{{build.dependencyIds}}])">
+										<img title="retry" alt="retry" src="${rootURL}/images/16x16/redo.png" />
+									</span>
+								{{else}}
+									<span class="pointer trigger" onclick="buildPipeline.showSpinner({{id}}); buildPipeline.rerunBuild({{id}}, '{{build.extId}}', [{{build.dependencyIds}}])">
+										<img title="retry" alt="retry" src="${rootURL}/images/16x16/redo.png" />
+									</span>
+								{{/if}}
 							{{/if}}
 						{{/if}}
 					{{/if}}

--- a/src/test/java/au/com/centrumsystems/hudson/plugin/buildpipeline/PipelineBuildTest.java
+++ b/src/test/java/au/com/centrumsystems/hudson/plugin/buildpipeline/PipelineBuildTest.java
@@ -333,6 +333,35 @@ public class PipelineBuildTest extends HudsonTestCase {
         assertFalse(pipelineBuildWithoutPermission.isReadyToBeManuallyBuilt());
     }
 
+    public void testTwoUpstreamRebuild() throws Exception {
+        FreeStyleProject a = createFreeStyleProject("A");
+        FreeStyleProject b = createFreeStyleProject("B");
+        FreeStyleProject c = createFreeStyleProject("C");
+
+        a.getPublishersList().add(new BuildTrigger("C", false));
+        b.getPublishersList().add(new BuildTrigger("C", false));
+
+        Hudson.getInstance().rebuildDependencyGraph();
+
+        FreeStyleBuild buildB = buildAndAssertSuccess(b);
+
+        waitUntilNoActivity();
+
+
+        FreeStyleBuild buildC = c.getLastBuild();
+
+        assertNotNull(buildC);
+
+        PipelineBuild pipelineBuild = new PipelineBuild(buildC, c, buildB);
+        PipelineBuild upstream = pipelineBuild.getUpstreamPipelineBuild();
+        assertEquals("1", upstream.getCurrentBuildNumber());
+        assertEquals(b.getFullName(),  upstream.getProject().getFullName());
+        assertFalse(upstream.isManualTrigger());
+
+
+
+    }
+
 }
 
 


### PR DESCRIPTION
If a job has two upstream dependencies and it has been triggered by anything except the manual trigger it will always take the first upstream job as the upstream dependency even if it is incorrect. Added check to not add a null Cause if upstream build is null.