### PR TITLE
[Fixed JENKINS-22210]: restarting the failed job manually

### DIFF
--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -65,8 +65,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -463,45 +461,6 @@ public class BuildPipelineView extends View {
         }
 
         return triggerBuild(triggerProject, upstreamBuild, buildParametersAction);
-    }
-
-    /**
-     * @param triggerProjectName
-     *            the triggerProjectName
-     * @return the number of re-tried build
-     */
-    @JavaScriptMethod
-    public int retryBuild(final String triggerProjectName) {
-        LOGGER.fine("Retrying build again: " + triggerProjectName); //$NON-NLS-1$
-        final AbstractProject<?, ?> triggerProject = (AbstractProject<?, ?>) super.getJob(triggerProjectName);
-        triggerProject.scheduleBuild(new MyUserIdCause());
-
-        return triggerProject.getNextBuildNumber();
-    }
-
-    /**
-     * @param externalizableId
-     *            the externalizableId
-     * @return the number of re-run build
-     */
-    @JavaScriptMethod
-    public int rerunBuild(final String externalizableId) {
-        LOGGER.fine("Running build again: " + externalizableId); //$NON-NLS-1$
-        final AbstractBuild<?, ?> triggerBuild = (AbstractBuild<?, ?>) Run.fromExternalizableId(externalizableId);
-        final AbstractProject<?, ?> triggerProject = triggerBuild.getProject();
-        final Future<?> future = triggerProject.scheduleBuild2(triggerProject.getQuietPeriod(), new MyUserIdCause(),
-                removeUserIdCauseActions(triggerBuild.getActions()));
-
-        AbstractBuild<?, ?> result = triggerBuild;
-        try {
-            result = (AbstractBuild<?, ?>) future.get();
-        } catch (final InterruptedException e) {
-            e.printStackTrace();
-        } catch (final ExecutionException e) {
-            e.printStackTrace();
-        }
-
-        return result.getNumber();
     }
 
     /**

--- a/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/bpp.jelly
+++ b/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/bpp.jelly
@@ -109,7 +109,7 @@
 						{{#if build.isSuccess}}
 							{{#if ${!from.triggerOnlyLatestJob}}}
 							<j:if test="${from.hasBuildPermission()}">
-							<span class="pointer trigger" onclick="buildPipeline.showSpinner({{id}}); buildPipeline.rerunBuild({{id}}, '{{build.extId}}', [{{build.dependencyIds}}])">
+							<span class="pointer trigger" onclick="buildPipeline.showSpinner({{id}}); buildPipeline.triggerBuild({{id}}, '{{upstream.projectName}}', {{upstream.buildNumber}}, '{{project.name}}', [{{build.dependencyIds}}])">
 								<img title="re-run" alt="re-run" src="${rootURL}/images/16x16/redo.png" />
 							</span>
 							</j:if>
@@ -118,7 +118,7 @@
 							{{#if ${from.triggerOnlyLatestJob}}}
 								{{#if build.isLatestBuild}}
 									{{#if build.isUpstreamBuildLatest}}
-									<span class="pointer trigger" onclick="buildPipeline.showSpinner({{id}}); buildPipeline.rerunBuild({{id}}, '{{build.extId}}', [{{build.dependencyIds}}])">
+									<span class="pointer trigger" onclick="buildPipeline.showSpinner({{id}}); buildPipeline.triggerBuild({{id}}, '{{upstream.projectName}}', {{upstream.buildNumber}}, '{{project.name}}', [{{build.dependencyIds}}])">
 										<img title="retry" alt="retry" src="${rootURL}/images/16x16/redo.png" />
 									</span>
 									{{/if}}

--- a/src/main/webapp/js/build-pipeline.js
+++ b/src/main/webapp/js/build-pipeline.js
@@ -81,18 +81,6 @@ BuildPipeline.prototype = {
 			buildPipeline.updateNextBuildAndShowProgress(id, data.responseObject(), dependencyIds);
 		});
 	},
-	retryBuild : function(id, triggerProjectName, dependencyIds) {
-		var buildPipeline = this;
-		buildPipeline.viewProxy.retryBuild(triggerProjectName, function(data){
-			buildPipeline.updateNextBuildAndShowProgress(id, data.responseObject(), dependencyIds);
-		});
-	},
-	rerunBuild : function(id, buildExternalizableId, dependencyIds) {
-		var buildPipeline = this;
-		buildPipeline.viewProxy.rerunBuild(buildExternalizableId, function(data){
-			buildPipeline.updateNextBuildAndShowProgress(id, data.responseObject(), dependencyIds);
-		});
-	},
 	showSpinner : function(id){
 		jQuery("#status-bar-" + id).html('<table class="progress-bar" align="center"><tbody><tr class="unknown"><td></td></tr></tbody></table>');
 		jQuery("#icons-" + id).empty();


### PR DESCRIPTION
Restarting the failed job manually will reflect in changes in the pipeline and allow you to proceed with the next build in the pipeline.

Just made changes to use 'triggerBuild' function instead of 'rebuild' and 'rerun'. 'triggerBuild' provides information about the upstream build, where two others don't. Restarting or rerunning was causing a build not to be considered as a part of the pipeline (where it should actually be).