### PR TITLE
Revert "[Fixed JENKINS-22210]: restarting the failed job manually"

### DIFF
--- a/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/bpp.jelly
+++ b/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/bpp.jelly
@@ -109,7 +109,7 @@
 						{{#if build.isSuccess}}
 							{{#if ${!from.triggerOnlyLatestJob}}}
 							<j:if test="${from.hasBuildPermission()}">
-							<span class="pointer trigger" onclick="buildPipeline.showSpinner({{id}}); buildPipeline.triggerBuild({{id}}, '{{upstream.projectName}}', {{upstream.buildNumber}}, '{{project.name}}', [{{build.dependencyIds}}])">
+							<span class="pointer trigger" onclick="buildPipeline.showSpinner({{id}}); buildPipeline.rerunBuild({{id}}, '{{build.extId}}', [{{build.dependencyIds}}])">
 								<img title="re-run" alt="re-run" src="${rootURL}/images/16x16/redo.png" />
 							</span>
 							</j:if>
@@ -118,7 +118,7 @@
 							{{#if ${from.triggerOnlyLatestJob}}}
 								{{#if build.isLatestBuild}}
 									{{#if build.isUpstreamBuildLatest}}
-									<span class="pointer trigger" onclick="buildPipeline.showSpinner({{id}}); buildPipeline.triggerBuild({{id}}, '{{upstream.projectName}}', {{upstream.buildNumber}}, '{{project.name}}', [{{build.dependencyIds}}])">
+									<span class="pointer trigger" onclick="buildPipeline.showSpinner({{id}}); buildPipeline.rerunBuild({{id}}, '{{build.extId}}', [{{build.dependencyIds}}])">
 										<img title="retry" alt="retry" src="${rootURL}/images/16x16/redo.png" />
 									</span>
 									{{/if}}

--- a/src/main/webapp/js/build-pipeline.js
+++ b/src/main/webapp/js/build-pipeline.js
@@ -81,6 +81,18 @@ BuildPipeline.prototype = {
 			buildPipeline.updateNextBuildAndShowProgress(id, data.responseObject(), dependencyIds);
 		});
 	},
+	retryBuild : function(id, triggerProjectName, dependencyIds) {
+		var buildPipeline = this;
+		buildPipeline.viewProxy.retryBuild(triggerProjectName, function(data){
+			buildPipeline.updateNextBuildAndShowProgress(id, data.responseObject(), dependencyIds);
+		});
+	},
+	rerunBuild : function(id, buildExternalizableId, dependencyIds) {
+		var buildPipeline = this;
+		buildPipeline.viewProxy.rerunBuild(buildExternalizableId, function(data){
+			buildPipeline.updateNextBuildAndShowProgress(id, data.responseObject(), dependencyIds);
+		});
+	},
 	showSpinner : function(id){
 		jQuery("#status-bar-" + id).html('<table class="progress-bar" align="center"><tbody><tr class="unknown"><td></td></tr></tbody></table>');
 		jQuery("#icons-" + id).empty();


### PR DESCRIPTION
Revert PR #66 since it breaks the following test, found by @KostyaSha.
1. Create FreestyleProject A, B, C
2. For project B under "Build Triggers" tick "Build after other projects are built" and enter A
3. For project C under "Build Triggers" tick "Build after other projects are built" and enter B
4. Trigger project A and wait until C has been built
5. Create Build Pipeline View and choose project A as initial project.
6. Rebuild B by clicking on B:s box 

B should be rebuilt but it fails.