### PR TITLE
Collect only parameters not all variables.

### DIFF
--- a/src/main/java/au/com/centrumsystems/hudson/plugin/util/BuildUtil.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/util/BuildUtil.java
@@ -39,7 +39,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Provides helper methods for #hudson.model.AbstractBuild
@@ -166,14 +165,15 @@ public final class BuildUtil {
     public static Map<String, String> getUnsensitiveParameters(final AbstractBuild<?, ?> build) {
         final Map<String, String> retval = new HashMap<String, String>();
         if (build != null) {
-            retval.putAll(build.getBuildVariables());
-            final Set<String> sensitiveBuildVariables = build.getSensitiveBuildVariables();
-            if (sensitiveBuildVariables != null) {
-                for (String paramName : sensitiveBuildVariables) {
-                    if (retval.containsKey(paramName)) {
+            final ParametersAction action = build.getAction(ParametersAction.class);
+            if (action != null) {
+                for (ParameterValue value : action.getParameters()) {
+                    
+                    if (value.isSensitive()) {
                         // We have the choice to hide the parameter or to replace it with special characters
-                        retval.put(paramName, "********");
-                        //retval.remove(paramName);
+                        retval.put(value.getName(), "********");
+                    } else {
+                        retval.put(value.getName(), value.createVariableResolver(build).resolve(value.getName()));
                     }
                 }
             }
@@ -181,5 +181,5 @@ public final class BuildUtil {
 
         return retval;
     }
-
+    
 }


### PR DESCRIPTION
Collect only parameters because build variables can contains more then parameters. For example plugins can contribute. I hit an issue with envinject-plugin which adds environment variables from slave and this slave was very low responsive. This slave caused that the view page was not able to display in browser (contributing of envinject-plugin takes several minutes). I think that we do not need more then parameters.