### PR TITLE
removing url host part when opening the dialog

### DIFF
--- a/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/bpp.jelly
+++ b/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/bpp.jelly
@@ -63,7 +63,7 @@
 				{{#unless project.disabled}}
 				<div class="status-bar" id="status-bar-{{id}}">
 					{{#if build.isBuilding}}
-						<div class="pointer" onclick="buildPipeline.fillDialog('${app.rootUrl}{{build.url}}console', 'Console output for {{project.name}} #{{build.number}}')">
+						<div class="pointer" onclick="buildPipeline.fillDialog('${rootUrl}{{build.url}}console', 'Console output for {{project.name}} #{{build.number}}')">
 							<table class="progress-bar" align="center">
 								<tbody>
 									<tr title="Estimated remaining time: {{build.estimatedRemainingTime}}">


### PR DESCRIPTION
Hey,
   I'm running  Jenkins behind apache http and the console dialog does not work because the url is absolute, it has the jenkins server host and port. 
  This PR should fix it

Sebi
