### PR TITLE
Fix msie detection, jQuery deprecates $.browser from 1.3+ removed from 1.9+

### DIFF
--- a/src/main/webapp/js/jquery.fancybox-1.3.4.js
+++ b/src/main/webapp/js/jquery.fancybox-1.3.4.js
@@ -26,7 +26,7 @@
 
 		titleHeight = 0, titleStr = '', start_pos, final_pos, busy = false, fx = $.extend($('<div/>')[0], { prop: 0 }),
 
-		isIE6 = $.browser.msie && $.browser.version < 7 && !window.XMLHttpRequest,
+		isIE6 = $.browser && $.browser.msie && $.browser.version < 7 && !window.XMLHttpRequest,
 
 		/*
 		 * Private methods 


### PR DESCRIPTION
Ideally, plugins should use modernizer now for browser shimming.