### PR TITLE
Support Build Flow Job

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,12 @@
             <version>18.0</version>
             <scope>provided</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>com.cloudbees.plugins</groupId>
+            <artifactId>build-flow-plugin</artifactId>
+            <version>0.18</version>
+        </dependency>
 
 	</dependencies>
 

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildForm.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildForm.java
@@ -1,18 +1,19 @@
 package au.com.centrumsystems.hudson.plugin.buildpipeline;
 
+import com.cloudbees.plugins.flow.FlowRun;
+import com.cloudbees.plugins.flow.JobInvocation;
+import com.google.common.primitives.Ints;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.ItemGroup;
 import hudson.model.ParametersDefinitionProperty;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
 
+import org.jgrapht.DirectedGraph;
+import org.jgrapht.traverse.DepthFirstIterator;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
 
 /**
@@ -104,6 +105,75 @@ public class BuildForm {
             }
         }
         parameters = paramList;
+
+        if(pipelineBuild.getCurrentBuild() instanceof FlowRun){
+            FlowRun flowRun = (FlowRun) pipelineBuild.getCurrentBuild();
+            traverseBuildFlowRunDownstreams(context, dependencies, flowRun.getJobsGraph(), flowRun.getStartJob(), parentPath);
+        }
+    }
+
+    //trasverse all of downstreams of the build flow run
+    private void traverseBuildFlowRunDownstreams(ItemGroup context, List<BuildForm> dependencies, final DirectedGraph<JobInvocation, FlowRun.JobEdge> allJobsGraphs, final JobInvocation jobInvocation, final Collection<AbstractProject<?, ?>> parentPath)  {
+        final Collection<AbstractProject<?, ?>> forkedPath = new LinkedHashSet<AbstractProject<?, ?>>(parentPath);
+        Set<FlowRun.JobEdge> edges = allJobsGraphs.outgoingEdgesOf(jobInvocation);
+        for (FlowRun.JobEdge edge : edges) {
+            if(needTrasverse(allJobsGraphs, edge)){
+                try {
+                    PipelineBuild downstream = new PipelineBuild((AbstractBuild<?, ?>)edge.getTarget().getBuild(), edge.getTarget().getProject(), (AbstractBuild<?, ?>)jobInvocation.getBuild());
+                    if (forkedPath.add(downstream.getProject())) {
+                        BuildForm bf = new BuildForm(context, downstream, forkedPath);
+                        traverseBuildFlowRunDownstreams(context, bf.dependencies, allJobsGraphs, edge.getTarget(), parentPath);
+                        dependencies.add(bf);
+                    }
+                } catch (ExecutionException e) {
+                    e.printStackTrace();
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+    private boolean needTrasverse(DirectedGraph<JobInvocation, FlowRun.JobEdge> jobsGraph, FlowRun.JobEdge edge){
+        Map<JobInvocation, Integer> vLd = getJobGraphVertexsLongestDistance(jobsGraph);
+        int sDistance = vLd.get(edge.getSource());
+        int tDistance = vLd.get(edge.getTarget());
+        List<JobInvocation> firstSources = new ArrayList<JobInvocation>(); //first element: distance, the rest: all of staring sources jobs with the same longest distance
+        for (FlowRun.JobEdge incomingEdeg: jobsGraph.incomingEdgesOf(edge.getTarget())){
+            int inSourceDistance = vLd.get(incomingEdeg.getSource());
+            if((inSourceDistance+1) == tDistance){
+                firstSources.add(incomingEdeg.getSource());
+            }
+        }
+        if((sDistance + 1) == tDistance && (firstSources.size() == 0 || firstSources.get(0).equals(edge.getSource()))){ //only add this downstream only, even when multiple starting source with the same longest distance
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+
+    private Map<JobInvocation, Integer> getJobGraphVertexsLongestDistance(DirectedGraph<JobInvocation, FlowRun.JobEdge> jobsGraph){
+        DepthFirstIterator<JobInvocation, FlowRun.JobEdge> iter =
+                new DepthFirstIterator<JobInvocation, FlowRun.JobEdge>(jobsGraph);
+
+        Map<JobInvocation, Integer> vLd = new HashMap<JobInvocation, Integer>();
+
+        while (iter.hasNext()) {
+            int distance = 0;
+            JobInvocation vertex = iter.next();
+            List<Integer> ivds = new ArrayList<Integer>(); // for calculate maximum distance
+            for (FlowRun.JobEdge incommingEdge: jobsGraph.incomingEdgesOf(vertex)){
+                if(vLd.containsKey(incommingEdge.getSource())){
+                    ivds.add(vLd.get(incommingEdge.getSource()));
+                }
+            }
+            if(!ivds.isEmpty()){
+                distance = Ints.max(Ints.toArray(ivds))+1;
+            }
+            vLd.put(vertex, distance);
+        }
+        return vLd;
     }
 
     public String getStatus() {

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildForm.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildForm.java
@@ -114,7 +114,7 @@ public class BuildForm {
         }
         parameters = paramList;
 
-        if(pipelineBuild.getCurrentBuild() instanceof FlowRun) {
+        if (pipelineBuild.getCurrentBuild() instanceof FlowRun) {
             final FlowRun flowRun = (FlowRun) pipelineBuild.getCurrentBuild();
             traverseBuildFlowRunDownstreams(context, dependencies, flowRun.getJobsGraph(), flowRun.getStartJob(), parentPath);
         }
@@ -122,6 +122,16 @@ public class BuildForm {
 
     /**
      * trasverse all of downstreams of the build flow run
+     * @param context
+     *          item group pipeline view belongs to, used to compute relative item names
+     * @param dependencies
+     *          the current dependencies for holding downstreams
+     * @param allJobsGraphs
+     *          build flow run jobs graph (jobs relationship)
+     * @param jobInvocation
+     *          build flow run
+     * @param parentPath
+     *          already traversed projects
      */
     private void traverseBuildFlowRunDownstreams(ItemGroup context, List<BuildForm> dependencies,
         final DirectedGraph<JobInvocation, FlowRun.JobEdge> allJobsGraphs, final JobInvocation jobInvocation,
@@ -149,16 +159,20 @@ public class BuildForm {
 
     /**
      * continue trasversing or not
+     * @param jobsGraph
+     *          build flow run jobs graph (jobs relationship)
+     * @param edge
+     *          a outgoing edge in jobs graph
      * @return true - continuing trasversing, false - not
      */
     private boolean needTrasverse(DirectedGraph<JobInvocation, FlowRun.JobEdge> jobsGraph, FlowRun.JobEdge edge) {
-        Map<JobInvocation, Integer> vLd = getJobGraphVertexsLongestDistance(jobsGraph);
-        int sDistance = vLd.get(edge.getSource());
-        int tDistance = vLd.get(edge.getTarget());
+        final Map<JobInvocation, Integer> vLd = getJobGraphVertexsLongestDistance(jobsGraph);
+        final int sDistance = vLd.get(edge.getSource());
+        final int tDistance = vLd.get(edge.getTarget());
         //first element: distance, the rest: all of staring sources jobs with the same longest distance
-        List<JobInvocation> firstSources = new ArrayList<JobInvocation>();
+        final List<JobInvocation> firstSources = new ArrayList<JobInvocation>();
         for (FlowRun.JobEdge incomingEdeg : jobsGraph.incomingEdgesOf(edge.getTarget())) {
-            int inSourceDistance = vLd.get(incomingEdeg.getSource());
+            final int inSourceDistance = vLd.get(incomingEdeg.getSource());
             if ((inSourceDistance + 1) == tDistance) {
                 firstSources.add(incomingEdeg.getSource());
             }
@@ -172,18 +186,20 @@ public class BuildForm {
     }
 
     /**
+     * @param jobsGraph build flow run jobs graph (jobs relationship)
+     *
      * @return get the longest distance (from the builf flow run vertex) for each vertex in the jobgraphs
      */
     private Map<JobInvocation, Integer> getJobGraphVertexsLongestDistance(DirectedGraph<JobInvocation, FlowRun.JobEdge> jobsGraph) {
-        DepthFirstIterator<JobInvocation, FlowRun.JobEdge> iter =
+        final DepthFirstIterator<JobInvocation, FlowRun.JobEdge> iter =
                 new DepthFirstIterator<JobInvocation, FlowRun.JobEdge>(jobsGraph);
 
-        Map<JobInvocation, Integer> vLd = new HashMap<JobInvocation, Integer>();
+        final Map<JobInvocation, Integer> vLd = new HashMap<JobInvocation, Integer>();
 
         while (iter.hasNext()) {
             int distance = 0;
-            JobInvocation vertex = iter.next();
-            List<Integer> ivds = new ArrayList<Integer>(); // for calculate maximum distance
+            final JobInvocation vertex = iter.next();
+            final List<Integer> ivds = new ArrayList<Integer>(); // for calculate maximum distance
             for (FlowRun.JobEdge incommingEdge : jobsGraph.incomingEdgesOf(vertex)) {
                 if (vLd.containsKey(incommingEdge.getSource())) {
                     ivds.add(vLd.get(incommingEdge.getSource()));

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildForm.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildForm.java
@@ -137,14 +137,14 @@ public class BuildForm {
         final DirectedGraph<JobInvocation, FlowRun.JobEdge> allJobsGraphs, final JobInvocation jobInvocation,
         final Collection<AbstractProject<?, ?>> parentPath) {
         final Collection<AbstractProject<?, ?>> forkedPath = new LinkedHashSet<AbstractProject<?, ?>>(parentPath);
-        Set<FlowRun.JobEdge> edges = allJobsGraphs.outgoingEdgesOf(jobInvocation);
+        final Set<FlowRun.JobEdge> edges = allJobsGraphs.outgoingEdgesOf(jobInvocation);
         for (FlowRun.JobEdge edge : edges) {
             if (needTrasverse(allJobsGraphs, edge)) {
                 try {
-                    PipelineBuild downstream = new PipelineBuild((AbstractBuild<?, ?>) edge.getTarget().getBuild(),
+                    final PipelineBuild downstream = new PipelineBuild((AbstractBuild<?, ?>) edge.getTarget().getBuild(),
                             edge.getTarget().getProject(), (AbstractBuild<?, ?>) jobInvocation.getBuild());
                     if (forkedPath.add(downstream.getProject())) {
-                        BuildForm bf = new BuildForm(context, downstream, forkedPath);
+                        final BuildForm bf = new BuildForm(context, downstream, forkedPath);
                         traverseBuildFlowRunDownstreams(context, bf.dependencies, allJobsGraphs, edge.getTarget(), parentPath);
                         dependencies.add(bf);
                     }
@@ -180,9 +180,8 @@ public class BuildForm {
         //only add this downstream only, even when multiple starting source with the same longest distance
         if ((sDistance + 1) == tDistance && (firstSources.size() == 0 || firstSources.get(0).equals(edge.getSource()))) {
             return true;
-        } else {
-            return false;
         }
+        return false;
     }
 
     /**

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineForm.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineForm.java
@@ -63,9 +63,13 @@ public class BuildPipelineForm {
         return buildGrids;
     }
 
-    private Integer getMaxColloumsOfBuildGrids(){
-        List<Integer> li = new ArrayList<Integer>();
-        for(BuildGrid bg: buildGrids){
+    /**
+     *
+     * @return the maximum number of build grid collumns
+     */
+    private Integer getMaxColloumsOfBuildGrids() {
+        final List<Integer> li = new ArrayList<Integer>();
+        for (BuildGrid bg : buildGrids) {
             li.add(bg.getColumns());
         }
         return Ints.max(Ints.toArray(li));

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineForm.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineForm.java
@@ -1,7 +1,9 @@
 package au.com.centrumsystems.hudson.plugin.buildpipeline;
 
 import com.google.common.collect.Iterables;
+import com.google.common.primitives.Ints;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
@@ -50,7 +52,7 @@ public class BuildPipelineForm {
      * @return width
      */
     public Integer getGridWidth() {
-        return projectGrid.getColumns();
+        return Ints.max(projectGrid.getColumns(), getMaxColloumsOfBuildGrids());
     }
 
     public Integer getGridHeight() {
@@ -61,4 +63,11 @@ public class BuildPipelineForm {
         return buildGrids;
     }
 
+    private Integer getMaxColloumsOfBuildGrids(){
+        List<Integer> li = new ArrayList<Integer>();
+        for(BuildGrid bg: buildGrids){
+            li.add(bg.getColumns());
+        }
+        return Ints.max(Ints.toArray(li));
+    }
 }


### PR DESCRIPTION
When the job is kind of build flow (via build-flow-plugin - https://github.com/jenkinsci/build-flow-plugin), we'll traverse its downstream builds with its job graphs and show them on the build grid. Of course, the project grid can't show their relationships well because project is used for showing static relationship among jobs, but build grid for dynamic (that is - it'll show whatever happened in that execution chain).