### PR TITLE
Show the project display name by default

### DIFF
--- a/src/main/groovy/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildJSONBuilder.groovy
+++ b/src/main/groovy/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildJSONBuilder.groovy
@@ -42,6 +42,7 @@ class BuildJSONBuilder {
 			project {
 				disabled(pipelineBuild.projectDisabled)
 				name(pipelineBuild.project.getRelativeNameFromGroup(context))
+				displayName(pipelineBuild.project.displayName)
 				url(pipelineBuild.projectURL)
 				health(pipelineBuild.projectHealth)
 				id(projectId)

--- a/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/bpp.jelly
+++ b/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/bpp.jelly
@@ -31,7 +31,11 @@
 								{{/if}}
 							{{/unless}}
 						{{/unless}}
-						{{project.name}}
+						{{#if project.displayName}}
+							{{project.displayName}}
+						{{else}}
+							{{project.name}}
+						{{/if}}
 					</a>
 				</div>
 			</td>


### PR DESCRIPTION
Set the BuildPipelineView to show the project's display name if it has one, otherwise default to the project's name (original functionality).