### PR TITLE
Fix for [JENKINS-29477] View bad for Build Pipeline Plugin

### DIFF
--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -16,6 +16,13 @@
 
 }
 
+#main-panel
+{
+	margin-left:0px;
+	display: inline-block;
+	min-width:100%;
+} 
+
 /******************** popup ***************************/
 #popup-iframe{
     width: 100%;


### PR DESCRIPTION
The added css rule removes the left margin, prevents overflowing content and expands the box to at least the width of the screen.

https://issues.jenkins-ci.org/browse/JENKINS-29477