### PR TITLE
Fix for JENKINS-24883 - Fix Copy Failures on Rerun

### DIFF
--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -429,14 +429,13 @@ public class BuildPipelineView extends View {
         final AbstractBuild<?, ?> triggerBuild = (AbstractBuild<?, ?>) Run.fromExternalizableId(externalizableId);
         final AbstractProject<?, ?> triggerProject = triggerBuild.getProject();
         
-        List<Action> actions = removeUserIdAndUpstreamCauseActions(triggerBuild.getActions());
+        final List<Action> actions = removeUserIdAndUpstreamCauseActions(triggerBuild.getActions());
         
         Cause.UpstreamCause upstreamCause = triggerBuild.getCause(Cause.UpstreamCause.class);
         
-        
-        if(upstreamCause != null) {
-        	LOGGER.fine(String.format("Adding Upstream Cause: %s", upstreamCause.getShortDescription()));
-        	actions.add(new CauseAction(upstreamCause));
+        if (upstreamCause != null) {
+            LOGGER.fine(String.format("Adding Upstream Cause: %s", upstreamCause.getShortDescription()));
+            actions.add(new CauseAction(upstreamCause));
         }
 
         
@@ -635,11 +634,11 @@ public class BuildPipelineView extends View {
        return retval;
    }
 
-    /**
+    /*
      * Removes any UserId and Upstream cause action from the given actions collection. This is used by downstream builds that inherit upstream actions.
-     * The downstream build can be initiated by another user that is different from the user who initiated the upstream build, so the
-     * downstream build needs to remove the old user action inherited from upstream, and add its own.  Also, reseting the upstream cause will prevent multiple upstream
-     * cause entries.
+     * The downstream build can be initiated by another user that is different from the user who initiated the upstream build, 
+     * so the downstream build needs to remove the old user action inherited from upstream, and add its own.  Also, reseting the 
+     * upstream cause will prevent multiple upstream cause entries.
      *
      * @param actions
      *            a collection of build actions.

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -430,14 +430,12 @@ public class BuildPipelineView extends View {
         final AbstractProject<?, ?> triggerProject = triggerBuild.getProject();
         
         final List<Action> actions = removeUserIdAndUpstreamCauseActions(triggerBuild.getActions());
-        
-        Cause.UpstreamCause upstreamCause = triggerBuild.getCause(Cause.UpstreamCause.class);
+        final Cause.UpstreamCause upstreamCause = triggerBuild.getCause(Cause.UpstreamCause.class);
         
         if (upstreamCause != null) {
             LOGGER.fine(String.format("Adding Upstream Cause: %s", upstreamCause.getShortDescription()));
             actions.add(new CauseAction(upstreamCause));
         }
-
         
         final Future<?> future = triggerProject.scheduleBuild2(triggerProject.getQuietPeriod(), new MyUserIdCause(),
                 actions);
@@ -615,7 +613,8 @@ public class BuildPipelineView extends View {
         return retval;
     }
     
-   /* Checks whether the given {@link Action} contains a reference to a {@link Cause.UpstreamCause} object.
+   /** 
+    * Checks whether the given {@link Action} contains a reference to a {@link Cause.UpstreamCause} object.
     *
     * @param buildAction
     *            the action to check.
@@ -634,11 +633,12 @@ public class BuildPipelineView extends View {
        return retval;
    }
 
-    /*
-     * Removes any UserId and Upstream cause action from the given actions collection. This is used by downstream builds that inherit upstream actions.
-     * The downstream build can be initiated by another user that is different from the user who initiated the upstream build, 
-     * so the downstream build needs to remove the old user action inherited from upstream, and add its own.  Also, reseting the 
-     * upstream cause will prevent multiple upstream cause entries.
+    /**
+     * Removes any UserId and Upstream cause action from the given actions collection. This is used by downstream 
+     * builds that inherit upstream actions.The downstream build can be initiated by another user that is different 
+     * from the user who initiated the upstream build, so the downstream build needs to remove the old user action 
+     * inherited from upstream, and add its own. Also, reseting the upstream cause will prevent multiple upstream 
+     * cause entries.
      *
      * @param actions
      *            a collection of build actions.


### PR DESCRIPTION
This patch will correctly determine and pass the upstream cause on stage reruns.
https://issues.jenkins-ci.org/browse/JENKINS-24883