### PR TITLE
[FIXED JENKINS-30577] : performance fix when determining view permissions

### DIFF
--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -870,8 +870,7 @@ public class BuildPipelineView extends View {
         boolean display = true;
         //tester la liste vide seulement en lecture
         if (READ.name.equals(p.name)) {
-          final Collection<TopLevelItem> items = this.getItems();
-          if (items == null || items.isEmpty()) {
+            if (isEmpty()) {
                 display = false;
             }
         } else {
@@ -880,5 +879,16 @@ public class BuildPipelineView extends View {
         }
 
         return display;
-    } 
+    }
+
+    /**
+     * determine if this view is empty
+     * @return true if this view contains zero items
+     */
+    private boolean isEmpty() {
+        if (noOfDisplayedBuilds == null || gridBuilder == null) {
+            return false;
+        }
+        return gridBuilder.build(this).isEmpty();
+    }
 }


### PR DESCRIPTION
This addresses a performance issue we ran into when calling getViews(). The problem specifically lies in hasPermission() which previously called getItems()