### PR TITLE
Fix for JENKINS-30801

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,11 @@ target
 work
 
 .checkstyle
+checkstyle-cachefile
 
 # IntelliJ
 .idea/
 *.iml
 *.ipr
 *.iws
+

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,12 @@
             <version>18.0</version>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.jenkins-ci</groupId>
+            <artifactId>test-annotations</artifactId>
+            <version>1.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -405,8 +405,11 @@ public class BuildPipelineView extends View {
     }
 
     /**
+     * Re-run a project, passing in the CauseActions from the previous completed {@link Run} so
+     * that the new run will appear in the same pipeline.
+     *
      * @param externalizableId
-     *            the externalizableId
+     *            the externalizableId of the Run. See {@link Run#getExternalizableId()}
      * @return the number of re-run build
      */
     @JavaScriptMethod

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -418,7 +418,7 @@ public class BuildPipelineView extends View {
         final AbstractBuild<?, ?> triggerBuild = (AbstractBuild<?, ?>) Run.fromExternalizableId(externalizableId);
         final AbstractProject<?, ?> triggerProject = triggerBuild.getProject();
         final Future<?> future = triggerProject.scheduleBuild2(triggerProject.getQuietPeriod(), new MyUserIdCause(),
-                filterCauseActions(triggerBuild.getActions()));
+                filterActions(triggerBuild.getActions()));
 
         AbstractBuild<?, ?> result = triggerBuild;
         try {
@@ -575,8 +575,8 @@ public class BuildPipelineView extends View {
 
 
     /**
-     * Filter out the list of actions so that it only includes CauseActions, but exclude
-     * CauseActions containing a UserIdCause
+     * Filter out the list of actions so that it only includes {@link ParametersAction} and
+     * CauseActions, but exclude CauseActions containing a UserIdCause
      *
      * We want to include CauseAction because that includes upstream cause actions, which
      * are inherited in downstream builds.
@@ -592,7 +592,7 @@ public class BuildPipelineView extends View {
      *            a collection of build actions.
      * @return a collection of build actions with all UserId causes removed.
      */
-    private List<Action> filterCauseActions(final List<Action> actions) {
+    private List<Action> filterActions(final List<Action> actions) {
         final List<Action> retval = new ArrayList<Action>();
         for (final Action action : actions) {
             if (action instanceof CauseAction) {
@@ -600,6 +600,9 @@ public class BuildPipelineView extends View {
                 if (!actionHasUserIdCause(causeAction)) {
                     retval.add(action);
                 }
+            }
+            else if (action instanceof ParametersAction) {
+                retval.add(action);
             }
         }
         return retval;

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -576,7 +576,7 @@ public class BuildPipelineView extends View {
 
     /**
      * Filter out the list of actions so that it only includes {@link ParametersAction} and
-     * CauseActions, but exclude CauseActions containing a UserIdCause
+     * CauseActions, removing the UserIdAction from the CauseAction's list of Causes.
      *
      * We want to include CauseAction because that includes upstream cause actions, which
      * are inherited in downstream builds.
@@ -597,9 +597,8 @@ public class BuildPipelineView extends View {
         for (final Action action : actions) {
             if (action instanceof CauseAction) {
                 final CauseAction causeAction = (CauseAction) action;
-                if (!actionHasUserIdCause(causeAction)) {
-                    retval.add(action);
-                }
+                filterOutUserIdCause(causeAction);
+                retval.add(causeAction);
             } else if (action instanceof ParametersAction) {
                 retval.add(action);
             }
@@ -608,17 +607,21 @@ public class BuildPipelineView extends View {
     }
 
     /**
+     * Filter out {@link UserIdCause} from the given {@link CauseAction}.
+     *
+     * We want to do this because re-run will want to contribute its own
+     * {@link UserIdCause}, not copy it from the previous run.
+     *
      * @param causeAction
-     *  the causeAction to query
+     *  the causeAction to remove UserIdCause from
      * @return whether the action has a {@link UserIdCause}
      */
-    private boolean actionHasUserIdCause(CauseAction causeAction) {
+    private void filterOutUserIdCause(CauseAction causeAction) {
         for (final Cause cause : causeAction.getCauses()) {
             if (cause instanceof UserIdCause) {
-                return true;
+                causeAction.getCauses().remove(cause);
             }
         }
-        return false;
     }
 
     /**

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -600,8 +600,7 @@ public class BuildPipelineView extends View {
                 if (!actionHasUserIdCause(causeAction)) {
                     retval.add(action);
                 }
-            }
-            else if (action instanceof ParametersAction) {
+            } else if (action instanceof ParametersAction) {
                 retval.add(action);
             }
         }

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -614,7 +614,6 @@ public class BuildPipelineView extends View {
      *
      * @param causeAction
      *  the causeAction to remove UserIdCause from
-     * @return whether the action has a {@link UserIdCause}
      */
     private void filterOutUserIdCause(CauseAction causeAction) {
         for (final Cause cause : causeAction.getCauses()) {

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -60,6 +60,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
@@ -598,7 +599,9 @@ public class BuildPipelineView extends View {
             if (action instanceof CauseAction) {
                 final CauseAction causeAction = (CauseAction) action;
                 filterOutUserIdCause(causeAction);
-                retval.add(causeAction);
+                if (!causeAction.getCauses().isEmpty()) {
+                    retval.add(causeAction);
+                }
             } else if (action instanceof ParametersAction) {
                 retval.add(action);
             }
@@ -616,9 +619,11 @@ public class BuildPipelineView extends View {
      *  the causeAction to remove UserIdCause from
      */
     private void filterOutUserIdCause(CauseAction causeAction) {
-        for (final Cause cause : causeAction.getCauses()) {
+        final Iterator<Cause> it = causeAction.getCauses().iterator();
+        while (it.hasNext()) {
+            final Cause cause = it.next();
             if (cause instanceof UserIdCause) {
-                causeAction.getCauses().remove(cause);
+                it.remove();
             }
         }
     }

--- a/src/main/webapp/js/build-pipeline.js
+++ b/src/main/webapp/js/build-pipeline.js
@@ -81,12 +81,6 @@ BuildPipeline.prototype = {
 			buildPipeline.updateNextBuildAndShowProgress(id, data.responseObject(), dependencyIds);
 		});
 	},
-	retryBuild : function(id, triggerProjectName, dependencyIds) {
-		var buildPipeline = this;
-		buildPipeline.viewProxy.retryBuild(triggerProjectName, function(data){
-			buildPipeline.updateNextBuildAndShowProgress(id, data.responseObject(), dependencyIds);
-		});
-	},
 	rerunBuild : function(id, buildExternalizableId, dependencyIds) {
 		var buildPipeline = this;
 		buildPipeline.viewProxy.rerunBuild(buildExternalizableId, function(data){


### PR DESCRIPTION
This PR fixes JENKINS-30801, a bug in the 're-run' feature where `Action` objects from a previous run were copied over to the re-run.

This is desirable for certain actions: `CauseAction` and `ParametersAction` are necessary to preserve upstream/downstream relationship and upstream trigger context.

However, `Action` is also used by `Builder` and `Publisher` to persist and summarize stuff about what they built (for example, test result information). This is meaningful for only that current `Run`, and should not be relevant at all for a re-run.

The fix here is to filter out actions and only include `CauseAction` and `ParametersAction`. `CauseAction` with a `UserId` cause is also excluded because the re-run will explicitly include a new `MyUserIdAction` for the user doing the re-triggering.

During this fix I also noticed 'retryRun' was not used, and looks like it would not provide any value as it does not preserve upstream / downstream relationships. This is likely leftover from JENKINS-22210 and its subsequent reverts.
