### PR TITLE
Fix JENKINS-33591: Manual steps broken in Jenkins ver. 1.653

### DIFF
--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -475,10 +475,12 @@ public class BuildPipelineView extends View {
             final Action buildParametersAction) {
         LOGGER.fine("Triggering build for project: " + triggerProject.getFullDisplayName()); //$NON-NLS-1$
         final List<Action> buildActions = new ArrayList<Action>();
-        final CauseAction causeAction = new CauseAction(new UserIdCause());
+        final List<Cause> causes = new ArrayList<Cause>();
+        causes.add(new UserIdCause());
         if (upstreamBuild != null) {
-            causeAction.getCauses().add(new Cause.UpstreamCause((Run<?, ?>) upstreamBuild));
+            causes.add(new Cause.UpstreamCause((Run<?, ?>) upstreamBuild));
         }
+        final CauseAction causeAction = new CauseAction(causes);
         buildActions.add(causeAction);
         ParametersAction parametersAction =
                 buildParametersAction instanceof ParametersAction


### PR DESCRIPTION
The cause list is immutable as described in the comments of
[JENKINS-33467](https://issues.jenkins-ci.org/browse/JENKINS-33467).