### PR TITLE
[JENKINS-34370] NPE coming from BuildForm.java in line 102

### DIFF
--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildForm.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildForm.java
@@ -98,7 +98,7 @@ public class BuildForm {
         projectId = project.getFullName().hashCode();
         final ParametersDefinitionProperty params = project.getProperty(ParametersDefinitionProperty.class);
         final ArrayList<String> paramList = new ArrayList<String>();
-        if (params != null) {
+        if (params != null && params.getParameterDefinitionNames() != null) {
             for (String p : params.getParameterDefinitionNames()) {
                 paramList.add(p);
             }


### PR DESCRIPTION
[JENKINS-34370](https://issues.jenkins-ci.org/browse/JENKINS-34370)

Context: line 102 of `BuildForm.java`.

The method `getParameterDefinitionNames()` from the class `ParametersDefinitionProperty.java` can return `null` and this is not being controlled before getting into the iteration of their expected `AbstractList<String>`.

@reviewbybees 