### PR TITLE
[FIXED JENKINS-34722] Performance improvement to not load all jobs

### DIFF
--- a/src/main/java/au/com/centrumsystems/hudson/plugin/util/BuildUtil.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/util/BuildUtil.java
@@ -24,8 +24,13 @@
  */
 package au.com.centrumsystems.hudson.plugin.util;
 
-import hudson.model.*;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Action;
 import hudson.model.Cause.UpstreamCause;
+import hudson.model.FileParameterValue;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -52,22 +57,26 @@ public final class BuildUtil {
      * @return - The next downstream build based on the upstream build and downstream project, or null if there is no downstream project.
      */
     public static AbstractBuild<?, ?> getDownstreamBuild(final AbstractProject<?, ?> downstreamProject,
-            final AbstractBuild<?, ?> upstreamBuild) {
+                                                         final AbstractBuild<?, ?> upstreamBuild) {
         if ((downstreamProject != null) && (upstreamBuild != null)) {
             // We set the MAX_DOWNSTREAM_DEPTH to search everything. This is to prevent breaking current behavior. This
             // flag can be set via groovy console, so users can adjust this parameter without having to restart Jenkins.
-            int max_downstream_depth = Integer.getInteger(BuildUtil.class.getCanonicalName() + ".MAX_DOWNSTREAM_DEPTH", Integer.MAX_VALUE);
+            final int maxDownstreamDepth = Integer.getInteger(BuildUtil.class.getCanonicalName() + ".MAX_DOWNSTREAM_DEPTH",
+                                                                                                    Integer.MAX_VALUE);
 
             // This can cause a major performance issue specifically when it tries to search through all of the builds,
             // and it never finds the correct upstream cause action. It might never be able to find the correct cause action because
             // a pipeline was executed and later terminated early. If that is the case, then we go through the entire list
             // of builds even though we terminated early.
             //
-            // To counter any potential performance issue the system property au.com.centurmsystems.hudson.plugin.util.BuildUtil.MAX_DOWNSTREAM_DEPTH
+            // To counter any potential performance issue the system property
+            // au.com.centurmsystems.hudson.plugin.util.BuildUtil.MAX_DOWNSTREAM_DEPTH
             // can be set which sets the max limit for how many builds should be loaded for the max depth.
 
             @SuppressWarnings("unchecked")
-            final List<AbstractBuild<?, ?>> downstreamBuilds = (List<AbstractBuild<?, ?>>) downstreamProject.getBuilds().limit(max_downstream_depth);
+            final List<AbstractBuild<?, ?>> downstreamBuilds = (List<AbstractBuild<?, ?>>) downstreamProject
+                                                                                                .getBuilds()
+                                                                                                .limit(maxDownstreamDepth);
             for (final AbstractBuild<?, ?> innerBuild : downstreamBuilds) {
                 final UpstreamCause cause = innerBuild.getCause(UpstreamCause.class);
                 if (cause != null && cause.pointsTo(upstreamBuild)) {
@@ -88,8 +97,8 @@ public final class BuildUtil {
      *            - The AbstractProject
      * @return - AbstractBuild's ParametersAction
      */
-    public static Action getAllBuildParametersAction(//
-            final AbstractBuild<?, ?> upstreamBuild, final AbstractProject<?, ?> downstreamProject) { //
+    public static Action getAllBuildParametersAction(final AbstractBuild<?, ?> upstreamBuild,
+                                                     final AbstractProject<?, ?> downstreamProject) {
         // Retrieve the List of Actions from the downstream project
         final ParametersAction dsProjectParametersAction = ProjectUtil.getProjectParametersAction(downstreamProject);
 

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/util/BuildUtil.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/util/BuildUtil.java
@@ -24,15 +24,8 @@
  */
 package au.com.centrumsystems.hudson.plugin.util;
 
-import hudson.model.Action;
-import hudson.model.ParameterValue;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.Cause;
+import hudson.model.*;
 import hudson.model.Cause.UpstreamCause;
-import hudson.model.CauseAction;
-import hudson.model.FileParameterValue;
-import hudson.model.ParametersAction;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -61,19 +54,24 @@ public final class BuildUtil {
     public static AbstractBuild<?, ?> getDownstreamBuild(final AbstractProject<?, ?> downstreamProject,
             final AbstractBuild<?, ?> upstreamBuild) {
         if ((downstreamProject != null) && (upstreamBuild != null)) {
+            // We set the MAX_UPSTREAM_DEPTH to search everything. This is to prevent breaking current behavior. This
+            // flag can be set via groovy console, so users can adjust this parameter without having to restart Jenkins.
+            int max_upstream_depth = Integer.getInteger(BuildUtil.class.getCanonicalName() + ".MAX_UPSTREAM_DEPTH", Integer.MAX_VALUE);
+
+            // This can cause a major performance issue specifically when it tries to search through all of the builds,
+            // and it never finds the correct upstream cause action. It might never be able to find the correct cause action because
+            // a pipeline was executed and later terminated early. If that is the case, then we go through the entire list
+            // of builds even though we terminated early.
+            //
+            // To counter any potential performance issue the system property au.com.centurmsystems.hudson.plugin.util.BuildUtil.MAX_UPSTREAM_DEPTH
+            // can be set which sets the max limit for how many builds should be loaded for the max depth.
+
             @SuppressWarnings("unchecked")
-            final List<AbstractBuild<?, ?>> downstreamBuilds = (List<AbstractBuild<?, ?>>) downstreamProject.getBuilds();
+            final List<AbstractBuild<?, ?>> downstreamBuilds = (List<AbstractBuild<?, ?>>) downstreamProject.getBuilds().limit(max_upstream_depth);
             for (final AbstractBuild<?, ?> innerBuild : downstreamBuilds) {
-                for (final CauseAction action : innerBuild.getActions(CauseAction.class)) {
-                    for (final Cause cause : action.getCauses()) {
-                        if (cause instanceof UpstreamCause) {
-                            final UpstreamCause upstreamCause = (UpstreamCause) cause;
-                            if (upstreamCause.getUpstreamProject().equals(upstreamBuild.getProject().getFullName())
-                                    && (upstreamCause.getUpstreamBuild() == upstreamBuild.getNumber())) {
-                                return innerBuild;
-                            }
-                        }
-                    }
+                final UpstreamCause cause = innerBuild.getCause(UpstreamCause.class);
+                if (cause != null && cause.pointsTo(upstreamBuild)) {
+                        return innerBuild;
                 }
             }
         }

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/util/BuildUtil.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/util/BuildUtil.java
@@ -54,20 +54,20 @@ public final class BuildUtil {
     public static AbstractBuild<?, ?> getDownstreamBuild(final AbstractProject<?, ?> downstreamProject,
             final AbstractBuild<?, ?> upstreamBuild) {
         if ((downstreamProject != null) && (upstreamBuild != null)) {
-            // We set the MAX_UPSTREAM_DEPTH to search everything. This is to prevent breaking current behavior. This
+            // We set the MAX_DOWNSTREAM_DEPTH to search everything. This is to prevent breaking current behavior. This
             // flag can be set via groovy console, so users can adjust this parameter without having to restart Jenkins.
-            int max_upstream_depth = Integer.getInteger(BuildUtil.class.getCanonicalName() + ".MAX_UPSTREAM_DEPTH", Integer.MAX_VALUE);
+            int max_downstream_depth = Integer.getInteger(BuildUtil.class.getCanonicalName() + ".MAX_DOWNSTREAM_DEPTH", Integer.MAX_VALUE);
 
             // This can cause a major performance issue specifically when it tries to search through all of the builds,
             // and it never finds the correct upstream cause action. It might never be able to find the correct cause action because
             // a pipeline was executed and later terminated early. If that is the case, then we go through the entire list
             // of builds even though we terminated early.
             //
-            // To counter any potential performance issue the system property au.com.centurmsystems.hudson.plugin.util.BuildUtil.MAX_UPSTREAM_DEPTH
+            // To counter any potential performance issue the system property au.com.centurmsystems.hudson.plugin.util.BuildUtil.MAX_DOWNSTREAM_DEPTH
             // can be set which sets the max limit for how many builds should be loaded for the max depth.
 
             @SuppressWarnings("unchecked")
-            final List<AbstractBuild<?, ?>> downstreamBuilds = (List<AbstractBuild<?, ?>>) downstreamProject.getBuilds().limit(max_upstream_depth);
+            final List<AbstractBuild<?, ?>> downstreamBuilds = (List<AbstractBuild<?, ?>>) downstreamProject.getBuilds().limit(max_downstream_depth);
             for (final AbstractBuild<?, ?> innerBuild : downstreamBuilds) {
                 final UpstreamCause cause = innerBuild.getCause(UpstreamCause.class);
                 if (cause != null && cause.pointsTo(upstreamBuild)) {

--- a/src/test/java/au/com/centrumsystems/hudson/plugin/util/BuildUtilTest.java
+++ b/src/test/java/au/com/centrumsystems/hudson/plugin/util/BuildUtilTest.java
@@ -53,7 +53,7 @@ public class BuildUtilTest extends HudsonTestCase {
     @Test
     public void testGetDownstreamBuildWithLimit() throws Exception {
         int max_upstream_depth = 3;
-        int total_proj2_builds = 5;
+        int total_proj2_builds = 10;
         System.setProperty(BuildUtil.class.getCanonicalName() + ".MAX_DOWNSTREAM_DEPTH", String.valueOf(max_upstream_depth));
 
         final FreeStyleProject proj1 = createFreeStyleProject();
@@ -75,10 +75,10 @@ public class BuildUtilTest extends HudsonTestCase {
         assertEquals("Proj2 does not have the correct number of builds.", total_proj2_builds + 1, proj2.getNextBuildNumber());
         RunLoadCounter.prepare(proj2);
 
-        assertFalse(RunLoadCounter.assertMaxLoads(proj2, max_upstream_depth - 1, new Callable<Boolean>() {
+        assertNull(RunLoadCounter.assertMaxLoads(proj2, max_upstream_depth + 2, new Callable<AbstractBuild<?, ?>>() {
             @Override
-            public Boolean call() throws Exception {
-                return BuildUtil.getDownstreamBuild(proj2, freeStyleBuild) != null;
+            public AbstractBuild<?, ?> call() throws Exception {
+                return BuildUtil.getDownstreamBuild(proj2, freeStyleBuild);
             }
         }));
     }


### PR DESCRIPTION
[JENKINS-34722](https://issues.jenkins-ci.org/browse/JENKINS-34722)

Currently the `BuildUtil.getDownstreamBuild` will iterate through all of the downstream project builds even if the upstream build never executed the downstream job. This PR adds a system property which can limit the number of downstream builds to search. A unit test has also been added to confirm that the limit is properly being reached and does not exceed the max number of builds to search for when looking for downstream builds.

@reviewbybees 