### PR TITLE
use list of manual triggers instead of single trigger

### DIFF
--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -533,12 +533,17 @@ public class BuildPipelineView extends View {
 
         List<AbstractBuildParameters> configs = null;
 
-        final BuildPipelineTrigger manualTrigger = upstreamProjectPublishersList.get(BuildPipelineTrigger.class);
-        if (manualTrigger != null) {
-            final Set<String> downstreamProjectsNames =
-                    Sets.newHashSet(Splitter.on(",").trimResults().split(manualTrigger.getDownstreamProjectNames()));
-            if (downstreamProjectsNames.contains(project.getFullName())) {
-                configs = manualTrigger.getConfigs();
+        final List<BuildPipelineTrigger> manualTriggers = upstreamProjectPublishersList.getAll(BuildPipelineTrigger.class);
+        for (BuildPipelineTrigger manualTrigger : manualTriggers) {
+            if (manualTrigger != null) {
+                final Set<String> downstreamProjectsNames =
+                        Sets.newHashSet(Splitter.on(",").trimResults().split(manualTrigger.getDownstreamProjectNames()));
+                if (downstreamProjectsNames.contains(project.getFullName())) {
+                    configs = manualTrigger.getConfigs();
+                    if (configs != null) {
+                        break;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Using gui user can add only one manual triggered job (the option of add another one is disabled)

But there is a possiblity to add more then one 'manual step' (Build other projects (manual step)) section as post-build action using the jenkins-dsl 
In described case we received error when we try to start second  manual triggered step ("No upstream trigger found for this project") 
When we base on list of BuildPipelineTrigger (not single trigger) everytking works fine 
  