### PR TITLE
Keep revision params on rerun of a build

### DIFF
--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -605,6 +605,8 @@ public class BuildPipelineView extends View {
                 }
             } else if (action instanceof ParametersAction) {
                 retval.add(action);
+            } else if ("hudson.plugins.git.RevisionParameterAction".equals(action.getClass().getName())) {
+                 retval.add(action);
             }
         }
         return retval;


### PR DESCRIPTION
I've encountered a bug with Jenkins where git revision params are not passed through to a rebuild done via a build pipeline. This happens due to `RevisionParameterAction` being filtered out in job rerun logic.

To avoid a dependency on the git plugin, this is doing a comparison against the class name. If you've got a better way to do this then I'm all ears!

I've confirmed locally that this fixes the issue and passes revision params correctly to a rerun.