### PR TITLE
Add missing jelly files for BuildPipelineView, SimpleRowHeader, NullC…

### DIFF
--- a/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/projectCardTemplate.jelly
+++ b/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/projectCardTemplate.jelly
@@ -1,0 +1,28 @@
+<j:jelly xmlns:j="jelly:core"
+         xmlns:st="jelly:stapler"
+         xmlns:d="jelly:define"
+         xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson"
+         xmlns:f="/lib/form">
+
+    <div class="build-card rounded">
+        <div class="header">
+            <a href="${rootURL}/{{url}}" title="{{name}}">{{name}}</a>
+        </div>
+        <div class="build-info">
+            {{#if lastSuccessfulBuildNumber}}
+            <ul>
+                <li>Health: <img src="${rootURL}/images/16x16/{{health}}" /></li>
+                <li>Build <abbr title="Number">No.</abbr>: <a href="${rootURL}/{{url}}{{lastSuccessfulBuildNumber}}">#{{lastSuccessfulBuildNumber}}</a></li>
+                {{#each lastSuccessfulBuildParams}}
+                <li>{{paramName}}: {{paramValue}}</li>
+                {{/each}}
+
+            </ul>
+            {{else}}
+            Awaiting Execution
+            {{/if}}
+        </div>
+    </div>
+
+</j:jelly>

--- a/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/extension/NullColumnHeader/rowHeader.jelly
+++ b/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/extension/NullColumnHeader/rowHeader.jelly
@@ -1,0 +1,17 @@
+<j:jelly xmlns:j="jelly:core"
+         xmlns:st="jelly:stapler"
+         xmlns:d="jelly:define"
+         xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson"
+         xmlns:f="/lib/form">
+
+    <div class="pipeline-info">
+        <div class="revision rounded">
+            <div class="title">Pipeline</div>
+            <div id="buildNumber${buildGrid.get(0,0).getId()}">
+                ${buildGrid.get(0,0).getRevision()}
+            </div>
+        </div>
+    </div>
+</j:jelly>
+

--- a/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/extension/SimpleRowHeader/projectCardTemplate.jelly
+++ b/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/extension/SimpleRowHeader/projectCardTemplate.jelly
@@ -1,0 +1,28 @@
+<j:jelly xmlns:j="jelly:core"
+         xmlns:st="jelly:stapler"
+         xmlns:d="jelly:define"
+         xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson"
+         xmlns:f="/lib/form">
+
+    <div class="build-card rounded">
+        <div class="header">
+            <a href="${rootURL}/{{url}}" title="{{name}}">{{name}}</a>
+        </div>
+        <div class="build-info">
+            {{#if lastSuccessfulBuildNumber}}
+            <ul>
+                <li>Health: <img src="${rootURL}/images/16x16/{{health}}" /></li>
+                <li>Build <abbr title="Number">No.</abbr>: <a href="${rootURL}/{{url}}{{lastSuccessfulBuildNumber}}">#{{lastSuccessfulBuildNumber}}</a></li>
+                {{#each lastSuccessfulBuildParams}}
+                <li>{{paramName}}: {{paramValue}}</li>
+                {{/each}}
+
+            </ul>
+            {{else}}
+            Awaiting Execution
+            {{/if}}
+        </div>
+    </div>
+
+</j:jelly>


### PR DESCRIPTION
The added files are copies.
.../AbstractNameValueHeader/projectCardTemplate.jelly -> .../BuildPipelineView/.
.../AbstractNameValueHeader/projectCardTemplate.jelly -> .../SimpleRowHeader/.
.../SimpleRowHeader/rowHeader.jelly -> .../NullColumnHeader/.

I understand that there probably is another way but I am not a java or Jenkins programmer. This was however how we resolved exceptions happening when running 
Jenkins 2.46.1
Build Pipeline Plugin 1.56

Ways to reproduce the error this PR is "fixing"
* Adding a new view (Dashboard)
* Add "Portlets at the top of the page"
* Add a "Build pipeline Dashboard View"
* Select a job
* Hit OK

Unzipped the jar, copied files and re-zipped the jar.


![screenshot from 2017-06-02 13-33-58](https://cloud.githubusercontent.com/assets/13114156/26724082/e643ae1e-4797-11e7-8083-81082cbd2ba9.png)
