### PR TITLE
JENKINS-47865: Fix returning a different upstream project

### DIFF
--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/PipelineBuild.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/PipelineBuild.java
@@ -310,15 +310,15 @@ public class PipelineBuild {
         String upstreamBuildName;
         final PipelineBuild previousPB = new PipelineBuild();
         if (this.upstreamBuild != null) {
-            upstreamBuildName = this.upstreamBuild.getProject().getName();
+            upstreamBuildName = this.upstreamBuild.getProject().getFullName();
         } else {
             upstreamBuildName = "";
         }
         if (upstreamProjects.size() > 0) {
             for (AbstractProject upstreamProject : upstreamProjects) {
-                if (upstreamProject.getName().equals(upstreamBuildName)) {
+                if (upstreamProject.getFullName().equals(upstreamBuildName)) {
                     previousProject = upstreamProject;
-                  break;
+                    break;
                 }
             }
             if (previousProject == null) {


### PR DESCRIPTION
If we just compare the name we can return an upstream job with the same
name but which is not the correct one.
We need to compare the full name (foo/bar/job) to ensure that we are
returning the upstream job which has called this job.