### PR TITLE
[JENKINS-51573] Fix the visibility of Empty views.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,17 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>jenkins-test-harness</artifactId>
+            <version>2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-auth</artifactId>
+            <version>1.0.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>${groovy.version}</version>

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -766,15 +766,7 @@ public class BuildPipelineView extends View {
     @Override
     public boolean hasPermission(final Permission p) {
         try {
-            boolean display = true;
-            if (READ.equals(p)) {
-                if (isEmpty()) {
-                    display = super.hasPermission(View.CONFIGURE);
-                }
-            } else {
-                display = super.hasPermission(p);
-            }
-            return display;
+            return super.hasPermission(p);
         } catch (Throwable t) {
             // JENKINS-44324This can be called from jenkins just determinig if it needs to show the
             // pipeline tab, so if there are any errors don't blow up

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -766,18 +766,7 @@ public class BuildPipelineView extends View {
     @Override
     public boolean hasPermission(final Permission p) {
         try {
-            boolean display = true;
-            //tester la liste vide seulement en lecture
-            if (READ.name.equals(p.name)) {
-                if (isEmpty()) {
-                    display = false;
-                }
-            } else {
-                //Pas en lecture => permission standard
-                display = super.hasPermission(p);
-            }
-
-            return display;
+            return isEmpty() ? this.getACL().hasPermission(View.CONFIGURE) : super.hasPermission(p);
         } catch (Throwable t) {
             // JENKINS-44324This can be called from jenkins just determinig if it needs to show the
             // pipeline tab, so if there are any errors don't blow up

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -766,7 +766,15 @@ public class BuildPipelineView extends View {
     @Override
     public boolean hasPermission(final Permission p) {
         try {
-            return isEmpty() ? this.getACL().hasPermission(View.CONFIGURE) : super.hasPermission(p);
+            boolean display = true;
+            if (READ.equals(p)) {
+                if (isEmpty()) {
+                    display = super.hasPermission(View.CONFIGURE);
+                }
+            } else {
+                display = super.hasPermission(p);
+            }
+            return display;
         } catch (Throwable t) {
             // JENKINS-44324This can be called from jenkins just determinig if it needs to show the
             // pipeline tab, so if there are any errors don't blow up

--- a/src/test/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineViewTest.java
+++ b/src/test/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineViewTest.java
@@ -421,7 +421,7 @@ public class BuildPipelineViewTest {
             @Override
             public void run() {
                 assertTrue(testView.hasPermission(View.READ));
-                assertTrue(!testView.hasPermission(View.CONFIGURE));
+                assertFalse(testView.hasPermission(View.CONFIGURE));
             }
         });
 

--- a/src/test/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineViewTest.java
+++ b/src/test/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineViewTest.java
@@ -414,7 +414,7 @@ public class BuildPipelineViewTest {
             @Override
             public void run() {
                 assertTrue(testView.hasPermission(View.READ));
-                assertTrue(!testView.hasPermission(View.CONFIGURE));
+                assertFalse(testView.hasPermission(View.CONFIGURE));
             }
         });
         ACL.impersonate(User.get("charlie").impersonate(), new Runnable() {
@@ -437,15 +437,15 @@ public class BuildPipelineViewTest {
         ACL.impersonate(User.get("bob").impersonate(), new Runnable() {
             @Override
             public void run() {
-                assertTrue(!emptyView.hasPermission(View.READ));
-                assertTrue(!emptyView.hasPermission(View.CONFIGURE));
+                assertTrue(emptyView.hasPermission(View.READ));
+                assertFalse(emptyView.hasPermission(View.CONFIGURE));
             }
         });
         ACL.impersonate(User.get("charlie").impersonate(), new Runnable() {
             @Override
             public void run() {
-                assertTrue(!emptyView.hasPermission(View.READ));
-                assertTrue(!emptyView.hasPermission(View.CONFIGURE));
+                assertFalse(emptyView.hasPermission(View.READ));
+                assertFalse(emptyView.hasPermission(View.CONFIGURE));
             }
         });
     }


### PR DESCRIPTION
@reviewbybees 

Empty views should be visible to users who have `View/Configure` permissions: https://issues.jenkins-ci.org/browse/JENKINS-51573