### PR TITLE
Amending CSS and Div Structure to accommodate variables listed

### DIFF
--- a/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/extension/PipelineHeaderExtension/columnHeader.jelly
+++ b/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/extension/PipelineHeaderExtension/columnHeader.jelly
@@ -7,7 +7,7 @@
     <!-- projects header -->
 
     <div class="pipeline-wrapper header">
-        <div class="pipeline-info"></div>
+        <div class="pipeline-info-header"></div>
         <div class="pipeline">
             <table class="pipelines">
                 <tbody>

--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -23,10 +23,20 @@ div.pipeline-wrapper.header {
     background-color: transparent;
 }
 
-div.pipeline-wrapper div.pipeline-info {
+div.pipeline-wrapper {
+    position: relative;
+    min-width: 100px;
+}
+
+div.pipeline-info {
     position: relative;
     float: left;
     min-width: 100px;
+    width: 20em;
+    height: 8.5em;
+    overflow-y: scroll;
+    margin-right: 20px;
+    box-shadow: 4px 4px 6px #555;
 }
 
 div.pipeline-wrapper div.pipeline {
@@ -245,7 +255,7 @@ table.pipelines td.next {
     background-color: #8b8989;
     text-align: center;
     padding: 4px;
-    min-height: 100px;
+    min-height: 8.5em;
 }
 
 .revision .title {


### PR DESCRIPTION
I've noticed that when multiple variables are listed on the Pipeline view it can push out pipelines below and eventually the layout is affected. I've included a screen capture representative of this.
![before](https://user-images.githubusercontent.com/37773304/40993799-76a5a206-68f2-11e8-9a48-7a3c2afd940d.png)

I've tested this on various machines with various browsers and different monitor resolutions.

This pull request suggests some minor changes to the CSS to accommodate for the over-spill from the variable list. As shown in this screen capture.
![after](https://user-images.githubusercontent.com/37773304/40993787-6bbd9344-68f2-11e8-94a9-1d78b0abab5a.png)

I have carried out the testing with Chrome, IE/Edge & Firefox on several machines and it has maintained the layout.

Thank you for considering this amendment.