### PR TITLE
[JENKINS-68022] Fix icon usage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,8 @@
 #!/usr/bin/env groovy
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+buildPlugin(configurations: [
+    [ platform: 'linux', jdk: '11' ],
+    [ platform: 'windows', jdk: '11' ],
+    [ platform: 'linux', jdk: '17' ],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.619</version>
+        <version>4.40</version>
+        <relativePath/>
     </parent>
     <artifactId>build-pipeline-plugin</artifactId>
     <version>1.5.9-SNAPSHOT</version>
@@ -29,8 +30,9 @@
         <pmd.config.file>pmd_rules.xml</pmd.config.file>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <groovy.version>1.8.6</groovy.version>
-        <selenium.version>2.48.0</selenium.version>
+        <selenium.version>4.1.4</selenium.version>
         <exclude.tests>**/functionaltest/*.java</exclude.tests>
+        <jenkins.version>2.337</jenkins.version>
     </properties>
     <developers>
         <developer>
@@ -45,17 +47,26 @@
             <email>alvizu@gmail.com</email>
         </developer>
     </developers>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.332.x</artifactId>
+                <version>1370.vfa_e23fe119c3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.0</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -73,7 +84,6 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>${groovy.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -93,20 +103,17 @@
             <!-- enables mocking of classes without default constructor (together with CGLIB) -->
             <groupId>org.objenesis</groupId>
             <artifactId>objenesis</artifactId>
-            <version>1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <!-- only necessary if Hamcrest matchers are used -->
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <version>1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>dashboard-view</artifactId>
-            <version>2.2</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -125,6 +132,18 @@
                     <artifactId>commons-io</artifactId>
                     <groupId>commons-io</groupId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -132,6 +151,12 @@
             <artifactId>selenium-chrome-driver</artifactId>
             <version>${selenium.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
@@ -144,24 +169,22 @@
             <artifactId>selenium-support</artifactId>
             <version>${selenium.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.8.3</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>test-annotations</artifactId>
-            <version>1.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -169,37 +192,6 @@
 
     <build>
         <plugins>
-            <!-- work-around for INFRA-588 -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.6</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.wagon</groupId>
-                        <artifactId>wagon-http</artifactId>
-                        <version>2.10</version>
-                        <type>jar</type>
-                    </dependency>
-                </dependencies>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.4</version>
-                <!--$NO-MVN-MAN-VER$ -->
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
-                <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.codehaus.gmaven</groupId>
                 <artifactId>gmaven-plugin</artifactId>
@@ -307,13 +299,6 @@
                     <releaseProfiles>web-tests</releaseProfiles>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.0</version>
-                <!--$NO-MVN-MAN-VER$ -->
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/bpp.jelly
+++ b/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/bpp.jelly
@@ -61,14 +61,14 @@
             <div class="icon-container">
             <j:if test="${from.isProjectParameterized()}">
                 <span class="pointer" onclick="buildPipeline.fillDialog('${app.rootUrl}${from.gridBuilder.firstJobLink}/build?delay=0sec', 'Starts the pipeline with parameters')">
-                    <img src="${rootURL}/images/24x24/clock.png" alt="Trigger a Pipeline" class="icon-with-caption"/>
-                                <span>Run</span>
+                    <l:icon src="icon-clock icon-md" alt="Trigger a Pipeline" />
+                    <span>Run</span>
                 </span>
             </j:if>
             <j:if test="${!from.isProjectParameterized()}">
               <a id="trigger-pipeline-button" href='#' onclick="$('triggerPipelineForm').submit()">
-                <img src="${rootURL}/images/24x24/clock.png" alt="Trigger a Pipeline" class="icon-with-caption"/>
-                                <span>Run</span>
+                <l:icon src="icon-clock icon-md" alt="Trigger a Pipeline" />
+                <span>Run</span>
               </a>
             </j:if>
           </div>
@@ -76,36 +76,36 @@
 
                 <div class="icon-container">
                     <a href="builds">
-                        <img src="${rootURL}/images/24x24/notepad.png" alt="Pipeline History" />
+                        <l:icon src="icon-notepad icon-md" alt="Pipeline History"/>
                         <span>History</span>
-                        </a>
-                    </div>
+                    </a>
+                </div>
 
                 <j:if test="${from.hasConfigurePermission()}">
                     <div class="icon-container">
                         <a href="configure">
-                            <img src="${rootURL}/images/24x24/setting.png" alt="Configure" />
+                            <l:icon src="icon-setting icon-md" alt="Configure" />
                             <span>Configure</span>
-                            </a>
-                        </div>
+                        </a>
+                    </div>
                     <div class="icon-container">
                         <a href="newJob">
-                            <img src="${rootURL}/images/24x24/new-package.png" alt="Add Step" />
+                            <l:icon src="icon-new-package icon-md" alt="Add Step" />
                             <span>Add Step</span>
-                            </a>
-                        </div>
+                        </a>
+                    </div>
                     <div class="icon-container">
                         <a href="delete">
-                            <img src="${rootURL}/images/24x24/edit-delete.png" />
+                            <l:icon src="icon-edit-delete icon-md" />
                             <span>Delete</span>
-                            </a>
-                        </div>
+                        </a>
+                    </div>
                     <div class="icon-container">
                         <a href="${rootURL}/manage">
-                            <img src="${rootURL}/images/24x24/setting.png" />
+                            <l:icon src="icon-setting icon-md" />
                             <span>Manage</span>
-                            </a>
-                        </div>
+                        </a>
+                    </div>
                 </j:if>
             </div>
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Since Jenkins `2.337` and https://github.com/jenkinsci/jenkins/pull/5778, the PNG icons were removed from Jenkins core. Only SVG files remains. 

With this PR, I propose a fix to use the image correctly on recent versions of Jenkins. See the before in [JENKINS-68022](https://issues.jenkins.io/browse/JENKINS-68022) 

Sadly, the first commit was mandatory here to be able to start the plugin locally, and so anyone can test the changes.

<details>
<summary>After:</summary>

![Screen Shot 2022-05-17 at 18 08 16](https://user-images.githubusercontent.com/985955/168858516-b7b372d4-81bd-4716-8336-4c9a99fe7af0.png)
</details>

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
