### PR TITLE
[JENKINS-72353] Do not include test harness in plugin binary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,12 +81,6 @@
             <version>2109.v930e1e518c15</version>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>matrix-auth</artifactId>
-            <version>1.0.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -76,11 +76,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-test-harness</artifactId>
-            <version>2109.v930e1e518c15</version>
-        </dependency>
-        <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <scope>provided</scope>

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView.java
@@ -433,9 +433,7 @@ public class BuildPipelineView extends View {
      * @param project
      *            - The project
      * @return URL - of the project
-     * @throws URISyntaxException
-     * @throws URISyntaxException
-     *             {@link URISyntaxException}
+     * @throws URISyntaxException on error
      */
     public String getProjectURL(final AbstractProject<?, ?> project) throws URISyntaxException {
         return project.getUrl();

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/Grid.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/Grid.java
@@ -47,7 +47,7 @@ public abstract class Grid<T> {
     /**
      * Determines the next row of the grid that should be populated.
      *
-     * Given (currentRow,currentColumn), find a row R>=currentRow such that
+     * Given (currentRow,currentColumn), find a row R&gt;=currentRow such that
      * the row R contains no project to any column to the right of current column.
      * That is, find the row in which we can place a sibling of the project
      * placed in (currentRow,currentColumn).

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/extension/AbstractNameValueHeader.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/extension/AbstractNameValueHeader.java
@@ -29,8 +29,8 @@ package au.com.centrumsystems.hudson.plugin.buildpipeline.extension;
  * .jelly files to inherit for children. See resource files:
  *
  * <ul>
- *   <li><tt>src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/extension/AbstractNameValueHeader/projectCardTemplate.jelly</tt></li>
- *   <li><tt>src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/extension/AbstractNameValueHeader/rowHeader.jelly</tt></li>
+*   <li><code>src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/extension/AbstractNameValueHeader/projectCardTemplate.jelly</code></li>
+ *   <li><code>src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/extension/AbstractNameValueHeader/rowHeader.jelly</code></li>
  * </ul>
  *
  * @author dalvizu

--- a/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/trigger/BuildPipelineTrigger.java
+++ b/src/main/java/au/com/centrumsystems/hudson/plugin/buildpipeline/trigger/BuildPipelineTrigger.java
@@ -277,7 +277,7 @@ public class BuildPipelineTrigger extends Notifier implements DependecyDeclarer 
         }
 
         /**
-         * Set help text to "Build Pipeline Plugin -> Manually Execute Downstream Project" Post Build action in JOB configuration page
+         * Set help text to "Build Pipeline Plugin -&gt; Manually Execute Downstream Project" Post Build action in JOB configuration page
          *
          * @return location of the help file
          */


### PR DESCRIPTION
## [JENKINS-72353](https://issues.jenkins.io/browse/JENKINS-72353) Do not include test harness in plugin binary

Earlier changes in the plugin ( d8d4635b4001feadd575e731c29a23e8e4593851 ) mistakenly included the Jenkins test harness as a compile time dependency.  That caused many jar files to be bundled into the plugin binary as transitive dependencies.  Prevent those transitive dependencies by relying on the Jenkins test harness dependency that is provided by the parent pom.

- [JENKINS-72353](https://issues.jenkins.io/browse/JENKINS-72353) Rely on jenkins test harnesss from parent

Includes two other relatively minor changes that resolve compilation warnings with Java 11.

- 16e3569ece51e17d862dbfee6e9a2afc59ada080 Include matrix-auth dependency only once
- f320bbf379f21617159dd90d3da7602a53869bb6 Fix Javadoc warnings from Java 11

Plugin size by version (noting that 2.0.1-xx is not released)
 
| Version  | Size     |
|----------|----------|
| 1.5.8    |  1455207 |
| 2.0.0    | 13001681 |
| 2.0.1-xx |   293989 |

These changes avoid the stack trace that is written to the Jenkins log with the 2.0.0 version of the plugin:

```
Failed to load org.jvnet.hudson.test.BuildWatcher$Listener
java.lang.ClassNotFoundException: org.junit.rules.ExternalResource
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:445)
	at jenkins.util.URLClassLoader2.findClass(URLClassLoader2.java:35)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:592)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
Caused: java.lang.NoClassDefFoundError: org/junit/rules/ExternalResource
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
```

### Testing done

Ran the plugin interactively while watching the console log to verify that there is no stack trace from attempts to locate a descriptor on the Jenkins test harness.  Created an upstream and a downstream job, then defined the build pipeline view to include them.  Confirmed that the icons look correct and the actions behave as expected without surprises.

Confirmed that the plugin binary is now only 293989 bytes instead of 13001681 bytes that are used by the 2.0.0 release.  The new plugin size is smaller than the last of the 1.x plugin releases as well.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
