### PR TITLE
[JENKINS-72581] Replace Prototype.js in the 'Run' button

### DIFF
--- a/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/bpp.jelly
+++ b/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/bpp.jelly
@@ -67,7 +67,7 @@
                 </span>
             </j:if>
             <j:if test="${!from.isProjectParameterized()}">
-              <a id="trigger-pipeline-button" href='#' onclick="$('triggerPipelineForm').submit()">
+              <a id="trigger-pipeline-button" href='#' onclick="document.getElementById('triggerPipelineForm').submit()">
                 <l:icon src="icon-clock icon-md" alt="Trigger a Pipeline" />
                                 <span>Run</span>
               </a>


### PR DESCRIPTION
## [JENKINS-72581] Replace Prototype.js in the "Run" button

[JENKINS-72581](https://issues.jenkins.io/browse/JENKINS-72581) describes the failure with Jenkins 2.426.2.  The "Run" button reports a JavaScript error rather than starting the build.  With this change, the build starts as expected.  Change was made based on the instructions in the [Prototype.js removal blog post](https://www.jenkins.io/blog/2023/05/12/removing-prototype-from-jenkins/).

Does not fix the "Delete" button.  That needs to be replaced with the modern version of delete that will use a modal dialog.

### Testing done

Interactive testing confirmed that I can duplicate the problem before this change and that after this change, the Run button behaves as expected.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
