### PR TITLE
Migrate from jQuery 1.x to 3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,9 +83,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>jquery</artifactId>
-            <version>1.12.4-1</version>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jquery3-api</artifactId>
         </dependency>
         <!-- Optional dependencies for using Spock -->
         <dependency>

--- a/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/bpp.jelly
+++ b/src/main/resources/au/com/centrumsystems/hudson/plugin/buildpipeline/BuildPipelineView/bpp.jelly
@@ -11,6 +11,7 @@
         <link rel="stylesheet" href="${from.cssUrl}" type="text/css" />
     </j:if>
 
+    <st:adjunct includes="io.jenkins.plugins.jquery3"/>
     <script src="${rootURL}/plugin/build-pipeline-plugin/js/jquery-migrate-1.2.1.min.js"></script>
     <script type="text/javascript" src="${rootURL}/plugin/build-pipeline-plugin/js/jquery-ui-1.8.14.custom.min.js"></script>
     <script type="text/javascript" src="${rootURL}/plugin/build-pipeline-plugin/js/handlebars-1.0.0.beta.6.js"></script>


### PR DESCRIPTION
We are about to deprecate the jQuery 1.x Jenkins library plugin, since it is not CSP compliant. In preparation for this deprecation, migrate from jQuery 1.x to 3.x.

To test this, I created an empty Build Pipeline view and verified in the browser's debugger that the `jQuery` object referred to jQuery 3.x.

@dalvizu Can this please be merged and released?