### PR TITLE
Remove Hudson from description

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Build Pipeline Plugin</name>
-    <description>This plugin provides build pipeline functionality to Hudson and Jenkins. This allows a chain of jobs to be visualised in a new view.  Manual jobs in the pipeline can be triggered by a user with the appropriate permissions manually confirming.</description>
+    <description>This plugin provides build pipeline visualation for Jenkins. This allows a chain of jobs to be visualised in a new view.  Manual jobs in the pipeline can be triggered by a user with the appropriate permissions manually confirming.</description>
     <url>https://github.com/jenkinsci/${project.artifactId}</url>
     <licenses>
         <license>


### PR DESCRIPTION
## Remove Hudson from description

Hudson project is end of life and this plugin no longer supports it

### Testing done

None

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
